### PR TITLE
feat: add dark theme with persistent toggle

### DIFF
--- a/Package/css/iframe.css
+++ b/Package/css/iframe.css
@@ -1,12 +1,53 @@
-:root {
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
+#TMEiframe {
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #eff1f3;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --danger: #db4437;
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --background-color: var(--color-bg);
+  --border-color: var(--border);
+  --gray-800: var(--text-primary);
+  --gray-600: var(--text-secondary);
+  --gray-400: var(--gray-3);
+  --gray-300: var(--surface-2);
+  --gray-200: var(--surface-1);
+  --danger-color: var(--danger);
+}
+
+@media (prefers-color-scheme: dark) {
+  #TMEiframe {
+    --color-bg: #1c1f24;
+    --surface-1: #1c1f24;
+    --surface-2: #272b33;
+    --text-primary: #f1f2f4;
+    --text-secondary: #b3b9c2;
+    --border: #2b3038;
+    --danger: #ff7b72;
+    --gray-0: #f1f2f4;
+    --gray-1: #d5d7da;
+    --gray-2: #b3b9c2;
+    --gray-3: #8f959e;
+  }
+}
+
+[data-theme="dark"] #TMEiframe {
+  --color-bg: #1c1f24;
+  --surface-1: #1c1f24;
+  --surface-2: #272b33;
+  --text-primary: #f1f2f4;
+  --text-secondary: #b3b9c2;
+  --border: #2b3038;
+  --danger: #ff7b72;
+  --gray-0: #f1f2f4;
+  --gray-1: #d5d7da;
+  --gray-2: #b3b9c2;
+  --gray-3: #8f959e;
 }
 
 #TMEiframe {

--- a/Package/css/popup.css
+++ b/Package/css/popup.css
@@ -1,30 +1,172 @@
 :root {
-  --primary-color: #4285f4;
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --danger-color-500: #eda19b;
-  --danger-color-bg: #fff8f7;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-  --google-green: #0f9d58;
-  --google-green-500: #87cdab;
-  --google-green-bg: #f7fffb;
-  --google-yellow: #f4b400;
-  --google-yellow-500: #f9d980;
-  --google-yellow-bg: #fffdf7;
-  --google-purple-hover: #6c61a4;
-  --google-purple: #8779cd;
-  --google-purple-500: #c3bce6;
-  --google-purple-bg: #fafafd;
-  /* TC + Emoji safe */
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #f6fafe;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --accent: #4285f4;
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+  --purple-hover: #6c61a4;
+  --purple: #8779cd;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --gray-4: #c4c7cb;
+  --gray-5: #b0b4ba;
+  --gray-6: #9ca0a5;
+  --gray-7: #7e8287;
+  --gray-8: #5f6368;
+  --gray-9: #3c4043;
+  --gray-10: #202833;
+  --gray-11: #171b1f;
+  --gray-12: #0b0e11;
+  --background-color: var(--color-bg);
+  --border-color: var(--border);
+  --gray-800: var(--text-primary);
+  --gray-600: var(--text-secondary);
+  --gray-400: var(--gray-3);
+  --gray-300: var(--surface-2);
+  --gray-200: var(--surface-1);
+  --primary-color: var(--accent);
+  --google-green: var(--success);
+  --google-green-500: var(--success-500);
+  --google-green-bg: var(--success-bg);
+  --google-yellow: var(--warning);
+  --google-yellow-500: var(--warning-500);
+  --google-yellow-bg: var(--warning-bg);
+  --google-purple-hover: var(--purple-hover);
+  --google-purple: var(--purple);
+  --google-purple-500: var(--purple-500);
+  --google-purple-bg: var(--purple-bg);
+  --danger-color: var(--danger);
+  --danger-color-500: var(--danger-500);
+  --danger-color-bg: var(--danger-bg);
   --ui-font: "Satoshi-Variable",
     "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC",
     system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #121417;
+    --surface-1: #1c1f24;
+    --surface-2: #272b33;
+    --text-primary: #f1f2f4;
+    --text-secondary: #b3b9c2;
+    --border: #2b3038;
+    --accent: #8ab4f8;
+    --danger: #ff7b72;
+    --danger-500: #ffb4ab;
+    --danger-bg: #3b1a1a;
+    --success: #6bcf9b;
+    --success-500: #245f43;
+    --success-bg: #0d2218;
+    --warning: #fdd663;
+    --warning-500: #5f4b16;
+    --warning-bg: #2b2515;
+    --purple-hover: #a58eff;
+    --purple: #b8a7ff;
+    --purple-500: #4a3a8a;
+    --purple-bg: #221f2f;
+    --gray-0: #f1f2f4;
+    --gray-1: #d5d7da;
+    --gray-2: #b3b9c2;
+    --gray-3: #8f959e;
+    --gray-4: #6b717a;
+    --gray-5: #4e535a;
+    --gray-6: #3c4043;
+    --gray-7: #31353a;
+    --gray-8: #272b33;
+    --gray-9: #1c1f24;
+    --gray-10: #16181d;
+    --gray-11: #121417;
+    --gray-12: #0b0e11;
+  }
+}
+
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #f6fafe;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --accent: #4285f4;
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+  --purple-hover: #6c61a4;
+  --purple: #8779cd;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --gray-4: #c4c7cb;
+  --gray-5: #b0b4ba;
+  --gray-6: #9ca0a5;
+  --gray-7: #7e8287;
+  --gray-8: #5f6368;
+  --gray-9: #3c4043;
+  --gray-10: #202833;
+  --gray-11: #171b1f;
+  --gray-12: #0b0e11;
+}
+
+[data-theme="dark"] {
+  --color-bg: #121417;
+  --surface-1: #1c1f24;
+  --surface-2: #272b33;
+  --text-primary: #f1f2f4;
+  --text-secondary: #b3b9c2;
+  --border: #2b3038;
+  --accent: #8ab4f8;
+  --danger: #ff7b72;
+  --danger-500: #ffb4ab;
+  --danger-bg: #3b1a1a;
+  --success: #6bcf9b;
+  --success-500: #245f43;
+  --success-bg: #0d2218;
+  --warning: #fdd663;
+  --warning-500: #5f4b16;
+  --warning-bg: #2b2515;
+  --purple-hover: #a58eff;
+  --purple: #b8a7ff;
+  --purple-500: #4a3a8a;
+  --purple-bg: #221f2f;
+  --gray-0: #f1f2f4;
+  --gray-1: #d5d7da;
+  --gray-2: #b3b9c2;
+  --gray-3: #8f959e;
+  --gray-4: #6b717a;
+  --gray-5: #4e535a;
+  --gray-6: #3c4043;
+  --gray-7: #31353a;
+  --gray-8: #272b33;
+  --gray-9: #1c1f24;
+  --gray-10: #16181d;
+  --gray-11: #121417;
+  --gray-12: #0b0e11;
 }
 
 html,
@@ -34,6 +176,7 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   color: var(--gray-800);
+  background-color: var(--background-color);
   font-family: var(--ui-font);
   font-weight: 400;
 }

--- a/Package/dist/contentScript.js
+++ b/Package/dist/contentScript.js
@@ -1,3 +1,24 @@
+const THEME_KEY = 'theme';
+
+function applyTheme(theme) {
+  const iframeContainer = document.getElementById("TMEiframe");
+  if (iframeContainer) {
+    iframeContainer.setAttribute('data-theme', theme);
+  }
+}
+
+chrome.storage.sync.get(THEME_KEY, (data) => {
+  const stored = data[THEME_KEY];
+  const theme = stored ? stored : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  applyTheme(theme);
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes[THEME_KEY]) {
+    applyTheme(changes[THEME_KEY].newValue);
+  }
+});
+
 // Track tab messages from the background script
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // Get the selected text from the webpage

--- a/Package/dist/inject.js
+++ b/Package/dist/inject.js
@@ -7,6 +7,11 @@ window.TME = {
         iframeContainer.id = "TMEiframe";
         iframeContainer.style.left = defaultX + "px";
         iframeContainer.style.top = defaultY + "px";
+        chrome.storage.sync.get('theme', (data) => {
+            const stored = data['theme'];
+            const theme = stored ? stored : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+            iframeContainer.setAttribute('data-theme', theme);
+        });
         // iframeContainer.style.resize = "vertical";
 
         const draggableBar = document.createElement("div");

--- a/Package/dist/scripts/theme.js
+++ b/Package/dist/scripts/theme.js
@@ -1,0 +1,39 @@
+(function() {
+  const THEME_KEY = 'theme';
+  const toggle = document.getElementById('themeToggle');
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    if (toggle) {
+      toggle.checked = theme === 'dark';
+    }
+  }
+
+  function init() {
+    chrome.storage.sync.get(THEME_KEY, (data) => {
+      const stored = data[THEME_KEY];
+      if (stored === 'light' || stored === 'dark') {
+        applyTheme(stored);
+      } else {
+        const osPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        applyTheme(osPrefersDark ? 'dark' : 'light');
+      }
+    });
+  }
+
+  init();
+
+  if (toggle) {
+    toggle.addEventListener('change', () => {
+      const theme = toggle.checked ? 'dark' : 'light';
+      applyTheme(theme);
+      chrome.storage.sync.set({ [THEME_KEY]: theme });
+    });
+  }
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync' && changes[THEME_KEY]) {
+      applyTheme(changes[THEME_KEY].newValue);
+    }
+  });
+})();

--- a/Package/popup.html
+++ b/Package/popup.html
@@ -212,6 +212,10 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="themeToggle" role="switch" aria-label="Toggle dark mode" />
+                            <label class="form-check-label" for="themeToggle" data-locale="darkModeLabel">Dark mode</label>
+                        </div>
                         <form id="dirForm" class="d-flex my-3">
                             <input type="text" class="form-control py-2 pe-5" autocomplete="off" id="dirInput" />
                             <button type="submit" data-bs-dismiss="modal" title="Save"
@@ -257,6 +261,7 @@
     <script defer src='dist/scripts/history.js'></script>
     <script defer src='dist/scripts/gemini.js'></script>
     <script defer src='dist/scripts/modal.js'></script>
+    <script defer src="dist/scripts/theme.js"></script>
     <script defer src="dist/popup.js"></script>
     <script src="vendor/bootstrap.min.js"></script>
 </body>

--- a/contrast-check.js
+++ b/contrast-check.js
@@ -1,0 +1,32 @@
+// Simple contrast checker for key token pairs
+const colors = {
+  light: {
+    bg: '#ffffff',
+    text: '#202833',
+    secondary: '#70757a'
+  },
+  dark: {
+    bg: '#121417',
+    text: '#f1f2f4',
+    secondary: '#b3b9c2'
+  }
+};
+
+function luminance(hex) {
+  const rgb = hex.replace('#','').match(/.{2}/g).map(c => parseInt(c,16)/255).map(v => {
+    return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
+  });
+  return 0.2126*rgb[0] + 0.7152*rgb[1] + 0.0722*rgb[2];
+}
+
+function contrast(fg, bg) {
+  const L1 = luminance(fg);
+  const L2 = luminance(bg);
+  return ((Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05)).toFixed(2);
+}
+
+['light','dark'].forEach(mode => {
+  console.log(`Mode: ${mode}`);
+  console.log('  text-primary vs bg:', contrast(colors[mode].text, colors[mode].bg));
+  console.log('  text-secondary vs bg:', contrast(colors[mode].secondary, colors[mode].bg));
+});

--- a/scss/iframe.scss
+++ b/scss/iframe.scss
@@ -1,15 +1,24 @@
-:root {
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-}
-
 #TMEiframe {
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #eff1f3;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --danger: #db4437;
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --background-color: var(--color-bg);
+  --border-color: var(--border);
+  --gray-800: var(--text-primary);
+  --gray-600: var(--text-secondary);
+  --gray-400: var(--gray-3);
+  --gray-300: var(--surface-2);
+  --gray-200: var(--surface-1);
+  --danger-color: var(--danger);
+
   position: fixed;
   width: 400px;
   height: 480px;
@@ -25,6 +34,36 @@
     height: calc(100% - 33px);
     border: none;
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  #TMEiframe {
+    --color-bg: #1c1f24;
+    --surface-1: #1c1f24;
+    --surface-2: #272b33;
+    --text-primary: #f1f2f4;
+    --text-secondary: #b3b9c2;
+    --border: #2b3038;
+    --danger: #ff7b72;
+    --gray-0: #f1f2f4;
+    --gray-1: #d5d7da;
+    --gray-2: #b3b9c2;
+    --gray-3: #8f959e;
+  }
+}
+
+[data-theme="dark"] #TMEiframe {
+  --color-bg: #1c1f24;
+  --surface-1: #1c1f24;
+  --surface-2: #272b33;
+  --text-primary: #f1f2f4;
+  --text-secondary: #b3b9c2;
+  --border: #2b3038;
+  --danger: #ff7b72;
+  --gray-0: #f1f2f4;
+  --gray-1: #d5d7da;
+  --gray-2: #b3b9c2;
+  --gray-3: #8f959e;
 }
 
 #TMEdrag {

--- a/scss/popup.scss
+++ b/scss/popup.scss
@@ -1,27 +1,7 @@
-:root {
-  --primary-color: #4285f4;
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --danger-color-500: #eda19b;
-  --danger-color-bg: #fff8f7;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-  --google-green: #0f9d58;
-  --google-green-500: #87cdab;
-  --google-green-bg: #f7fffb;
-  --google-yellow: #f4b400;
-  --google-yellow-500: #f9d980;
-  --google-yellow-bg: #fffdf7;
-  --google-purple-hover: #6c61a4;
-  --google-purple: #8779cd;
-  --google-purple-500: #c3bce6;
-  --google-purple-bg: #fafafd;
+@import 'theme';
 
-  /* TC + Emoji safe */
+/* TC + Emoji safe */
+:root {
   --ui-font: "Satoshi-Variable",
     "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC",
     system-ui, sans-serif,
@@ -35,6 +15,7 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   color: var(--gray-800);
+  background-color: var(--background-color);
   font-family: var(--ui-font);
   font-weight: 400;
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -1,0 +1,171 @@
+:root {
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #f6fafe;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --accent: #4285f4;
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+  --purple-hover: #6c61a4;
+  --purple: #8779cd;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --gray-4: #c4c7cb;
+  --gray-5: #b0b4ba;
+  --gray-6: #9ca0a5;
+  --gray-7: #7e8287;
+  --gray-8: #5f6368;
+  --gray-9: #3c4043;
+  --gray-10: #202833;
+  --gray-11: #171b1f;
+  --gray-12: #0b0e11;
+
+  --background-color: var(--color-bg);
+  --border-color: var(--border);
+  --gray-800: var(--text-primary);
+  --gray-600: var(--text-secondary);
+  --gray-400: var(--gray-3);
+  --gray-300: var(--surface-2);
+  --gray-200: var(--surface-1);
+  --primary-color: var(--accent);
+  --google-green: var(--success);
+  --google-green-500: var(--success-500);
+  --google-green-bg: var(--success-bg);
+  --google-yellow: var(--warning);
+  --google-yellow-500: var(--warning-500);
+  --google-yellow-bg: var(--warning-bg);
+  --google-purple-hover: var(--purple-hover);
+  --google-purple: var(--purple);
+  --google-purple-500: var(--purple-500);
+  --google-purple-bg: var(--purple-bg);
+  --danger-color: var(--danger);
+  --danger-color-500: var(--danger-500);
+  --danger-color-bg: var(--danger-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #121417;
+    --surface-1: #1c1f24;
+    --surface-2: #272b33;
+    --text-primary: #f1f2f4;
+    --text-secondary: #b3b9c2;
+    --border: #2b3038;
+    --accent: #8ab4f8;
+    --danger: #ff7b72;
+    --danger-500: #ffb4ab;
+    --danger-bg: #3b1a1a;
+    --success: #6bcf9b;
+    --success-500: #245f43;
+    --success-bg: #0d2218;
+    --warning: #fdd663;
+    --warning-500: #5f4b16;
+    --warning-bg: #2b2515;
+    --purple-hover: #a58eff;
+    --purple: #b8a7ff;
+    --purple-500: #4a3a8a;
+    --purple-bg: #221f2f;
+
+    --gray-0: #f1f2f4;
+    --gray-1: #d5d7da;
+    --gray-2: #b3b9c2;
+    --gray-3: #8f959e;
+    --gray-4: #6b717a;
+    --gray-5: #4e535a;
+    --gray-6: #3c4043;
+    --gray-7: #31353a;
+    --gray-8: #272b33;
+    --gray-9: #1c1f24;
+    --gray-10: #16181d;
+    --gray-11: #121417;
+    --gray-12: #0b0e11;
+  }
+}
+
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --surface-1: #ffffff;
+  --surface-2: #f6fafe;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+  --border: #dee2e6;
+  --accent: #4285f4;
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+  --purple-hover: #6c61a4;
+  --purple: #8779cd;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+
+  --gray-0: #ffffff;
+  --gray-1: #f6fafe;
+  --gray-2: #eff1f3;
+  --gray-3: #dadce0;
+  --gray-4: #c4c7cb;
+  --gray-5: #b0b4ba;
+  --gray-6: #9ca0a5;
+  --gray-7: #7e8287;
+  --gray-8: #5f6368;
+  --gray-9: #3c4043;
+  --gray-10: #202833;
+  --gray-11: #171b1f;
+  --gray-12: #0b0e11;
+}
+
+[data-theme="dark"] {
+  --color-bg: #121417;
+  --surface-1: #1c1f24;
+  --surface-2: #272b33;
+  --text-primary: #f1f2f4;
+  --text-secondary: #b3b9c2;
+  --border: #2b3038;
+  --accent: #8ab4f8;
+  --danger: #ff7b72;
+  --danger-500: #ffb4ab;
+  --danger-bg: #3b1a1a;
+  --success: #6bcf9b;
+  --success-500: #245f43;
+  --success-bg: #0d2218;
+  --warning: #fdd663;
+  --warning-500: #5f4b16;
+  --warning-bg: #2b2515;
+  --purple-hover: #a58eff;
+  --purple: #b8a7ff;
+  --purple-500: #4a3a8a;
+  --purple-bg: #221f2f;
+
+  --gray-0: #f1f2f4;
+  --gray-1: #d5d7da;
+  --gray-2: #b3b9c2;
+  --gray-3: #8f959e;
+  --gray-4: #6b717a;
+  --gray-5: #4e535a;
+  --gray-6: #3c4043;
+  --gray-7: #31353a;
+  --gray-8: #272b33;
+  --gray-9: #1c1f24;
+  --gray-10: #16181d;
+  --gray-11: #121417;
+  --gray-12: #0b0e11;
+}


### PR DESCRIPTION
## Summary
- introduce semantic color tokens with light/dark variants
- add Optional modal switch with stored theme preference
- sync theme across popup and injected iframe

## Testing
- `node contrast-check.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b147634832489250f0aced98607