### PR TITLE
feat: add theming with dark mode toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Assets
 Package.zip
+node_modules/

--- a/Package/css/iframe.css
+++ b/Package/css/iframe.css
@@ -1,19 +1,9 @@
-:root {
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-}
 
 #TMEiframe {
   position: fixed;
   width: 400px;
   height: 480px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   z-index: 10000;
   box-shadow: 0 8px 24px rgba(112, 144, 176, 0.25);
   border-radius: 8px;
@@ -28,14 +18,14 @@
 
 #TMEdrag {
   height: 32px;
-  background-color: var(--gray-300);
+  background-color: var(--surface-2);
   cursor: move;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 0 0 1rem;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border);
 }
 #TMEdrag::after {
   content: none !important;
@@ -48,7 +38,7 @@
 #TMElines div {
   width: 1px;
   height: 8px;
-  background-color: var(--gray-600);
+  background-color: var(--text-secondary);
 }
 
 #TMEeject {
@@ -66,13 +56,13 @@
 #TMEeject svg {
   width: 20px;
   height: 20px;
-  fill: var(--gray-600);
+  fill: var(--text-secondary);
 }
 #TMEeject:hover {
-  background: var(--danger-color);
+  background: var(--danger);
 }
 #TMEeject:hover svg {
-  fill: var(--background-color);
+  fill: var(--color-bg);
 }
 #TMEeject:active {
   box-shadow: none !important;

--- a/Package/css/popup.css
+++ b/Package/css/popup.css
@@ -1,31 +1,3 @@
-:root {
-  --primary-color: #4285f4;
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --danger-color-500: #eda19b;
-  --danger-color-bg: #fff8f7;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-  --google-green: #0f9d58;
-  --google-green-500: #87cdab;
-  --google-green-bg: #f7fffb;
-  --google-yellow: #f4b400;
-  --google-yellow-500: #f9d980;
-  --google-yellow-bg: #fffdf7;
-  --google-purple-hover: #6c61a4;
-  --google-purple: #8779cd;
-  --google-purple-500: #c3bce6;
-  --google-purple-bg: #fafafd;
-  /* TC + Emoji safe */
-  --ui-font: "Satoshi-Variable",
-    "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC",
-    system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
-}
 
 html,
 body {
@@ -33,8 +5,9 @@ body {
   box-sizing: border-box;
   overflow-y: auto;
   overflow-x: hidden;
-  color: var(--gray-800);
-  font-family: var(--ui-font);
+  background-color: var(--color-bg);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
   font-weight: 400;
 }
 
@@ -42,7 +15,7 @@ body {
 .brand {
   border-top-left-radius: 2rem;
   border-bottom-left-radius: 2rem;
-  background-color: var(--background-color);
+  background-color: var(--color-bg);
 }
 
 .input-group-prepend {
@@ -53,20 +26,20 @@ body {
   border-left: 0rem;
   border-top-right-radius: 2rem;
   border-bottom-right-radius: 2rem;
-  color: var(--gray-800);
+  color: var(--text-primary);
 }
 #searchInput::-moz-placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #searchInput::placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #searchInput:focus {
-  color: var(--gray-600);
-  background-color: var(--background-color);
-  border-color: var(--border-color);
+  color: var(--text-secondary);
+  background-color: var(--color-bg);
+  border-color: var(--border);
   outline: none;
   box-shadow: none;
 }
@@ -86,8 +59,8 @@ body {
   right: 0.75rem;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--gray-800);
-  background-color: var(--background-color);
+  color: var(--text-primary);
+  background-color: var(--color-bg);
   width: 2rem;
   height: 2rem;
   cursor: pointer;
@@ -103,17 +76,17 @@ body {
   padding-left: 1rem;
 }
 #apiInput::-moz-placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #apiInput::placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #apiInput:focus {
-  color: var(--gray-600);
-  background-color: var(--background-color);
-  border-color: var(--border-color);
+  color: var(--text-secondary);
+  background-color: var(--color-bg);
+  border-color: var(--border);
   outline: none;
   box-shadow: none;
 }
@@ -129,7 +102,7 @@ body {
   right: 1.5rem;
   top: 50%;
   transform: translateY(-50%);
-  background-color: var(--google-purple);
+  background-color: var(--purple);
   color: white;
   width: 2rem;
   height: 2rem;
@@ -140,7 +113,7 @@ body {
 }
 
 .modal-footer p a {
-  color: var(--google-purple);
+  color: var(--purple);
   font-weight: 700;
   text-decoration: none;
 }
@@ -151,17 +124,17 @@ body {
   padding-left: 1rem;
 }
 #dirInput::-moz-placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #dirInput::placeholder {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   font-weight: 300;
 }
 #dirInput:focus {
-  color: var(--gray-600);
-  background-color: var(--background-color);
-  border-color: var(--border-color);
+  color: var(--text-secondary);
+  background-color: var(--color-bg);
+  border-color: var(--border);
   outline: none;
   box-shadow: none;
 }
@@ -177,7 +150,7 @@ body {
   right: 1.5rem;
   top: 50%;
   transform: translateY(-50%);
-  background-color: var(--primary-color);
+  background-color: var(--accent);
   color: white;
   width: 2rem;
   height: 2rem;
@@ -189,7 +162,7 @@ body {
 
 /* list-group-item */
 .list-group-item {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   max-width: 100%;
   cursor: pointer;
 }
@@ -201,28 +174,28 @@ body {
 }
 
 .history-list:hover {
-  color: var(--google-green);
-  background-color: var(--google-green-bg);
-  border: 1px solid var(--google-green) !important;
+  color: var(--success);
+  background-color: var(--success-bg);
+  border: 1px solid var(--success) !important;
 }
 
 .favorite-list:hover {
-  color: var(--google-yellow);
-  background-color: var(--google-yellow-bg);
-  border: 1px solid var(--google-yellow) !important;
+  color: var(--warning);
+  background-color: var(--warning-bg);
+  border: 1px solid var(--warning) !important;
 }
 
 .delete-list:hover,
 .checked-list {
-  color: var(--danger-color);
-  background-color: var(--danger-color-bg);
-  border: 1px solid var(--danger-color) !important;
+  color: var(--danger);
+  background-color: var(--danger-bg);
+  border: 1px solid var(--danger) !important;
 }
 
 .summary-list:hover {
-  color: var(--google-purple);
-  background-color: var(--google-purple-bg);
-  border: 1px solid var(--google-purple) !important;
+  color: var(--purple);
+  background-color: var(--purple-bg);
+  border: 1px solid var(--purple) !important;
 }
 
 #searchHistoryList,
@@ -275,26 +248,26 @@ li:hover i.matched {
 
 /* checkbox */
 .form-check-input {
-  border-color: var(--border-color);
+  border-color: var(--border);
   min-width: 1rem;
   min-height: 1rem;
   margin-top: 0rem;
 }
 .form-check-input:focus-visible {
-  box-shadow: 0 0 0 0px var(--danger-color-500);
-  border-color: var(--danger-color);
+  box-shadow: 0 0 0 0px var(--danger-500);
+  border-color: var(--danger);
 }
 .form-check-input:focus {
-  box-shadow: 0 0 0 0px var(--danger-color-500);
-  border-color: var(--border-color);
+  box-shadow: 0 0 0 0px var(--danger-500);
+  border-color: var(--border);
 }
 .form-check-input:checked {
-  background-color: var(--danger-color);
-  border-color: var(--danger-color);
+  background-color: var(--danger);
+  border-color: var(--danger);
 }
 
 li:hover .form-check-input {
-  border-color: var(--danger-color-500);
+  border-color: var(--danger-500);
 }
 
 /* buttons */
@@ -303,65 +276,65 @@ li:hover .form-check-input {
   padding-left: 0.75rem;
 }
 .nav-link:hover {
-  color: var(--gray-800) !important;
+  color: var(--text-primary) !important;
 }
 
 .btn-light {
-  color: var(--gray-600);
-  background-color: var(--gray-300);
-  border: 1px solid var(--gray-300);
+  color: var(--text-secondary);
+  background-color: var(--surface-2);
+  border: 1px solid var(--surface-2);
 }
 .btn-light:hover {
-  border: 1px solid var(--gray-300);
+  border: 1px solid var(--surface-2);
 }
 
 .btn-maps {
-  background-color: var(--primary-color);
-  border: 1px solid var(--primary-color);
+  background-color: var(--accent);
+  border: 1px solid var(--accent);
 }
 
 .btn-delete {
-  background-color: var(--danger-color);
-  border: 1px solid var(--danger-color);
+  background-color: var(--danger);
+  border: 1px solid var(--danger);
 }
 
 #clearButton,
 #cancelButton,
 #clearButtonSummary {
-  color: var(--gray-600);
+  color: var(--text-secondary);
 }
 
 #clearButton:hover,
 #clearButtonSummary:hover {
-  background-color: var(--danger-color);
-  border: 1px solid var(--danger-color);
-  color: var(--background-color);
+  background-color: var(--danger);
+  border: 1px solid var(--danger);
+  color: var(--color-bg);
 }
 
 .btn-send {
-  background-color: var(--google-purple);
-  border: 1px solid var(--google-purple);
-  color: var(--background-color);
+  background-color: var(--purple);
+  border: 1px solid var(--purple);
+  color: var(--color-bg);
 }
 .btn-send:hover {
-  background-color: var(--google-purple-hover);
-  border: 1px solid var(--google-purple-hover);
-  color: var(--background-color);
+  background-color: var(--purple-hover);
+  border: 1px solid var(--purple-hover);
+  color: var(--color-bg);
 }
 .btn-send:active {
-  background-color: var(--google-purple-hover) !important;
-  border: 1px solid var(--google-purple-hover) !important;
-  color: var(--background-color) !important;
+  background-color: var(--purple-hover) !important;
+  border: 1px solid var(--purple-hover) !important;
+  color: var(--color-bg) !important;
 }
 .btn-send:focus-visible {
-  background-color: var(--google-purple);
-  box-shadow: 0 0 0 4px var(--google-purple-500);
-  color: var(--background-color);
+  background-color: var(--purple);
+  box-shadow: 0 0 0 4px var(--purple-500);
+  color: var(--color-bg);
 }
 .btn-send:disabled {
-  background-color: var(--google-purple);
-  border: 1px solid var(--google-purple);
-  color: var(--background-color);
+  background-color: var(--purple);
+  border: 1px solid var(--purple);
+  color: var(--color-bg);
   opacity: 0.65;
 }
 
@@ -371,7 +344,7 @@ li:hover .form-check-input {
 #geminiSummaryButton,
 #videoSummaryButton {
   border: none;
-  color: var(--gray-600);
+  color: var(--text-secondary);
   position: relative;
 }
 
@@ -392,81 +365,81 @@ li:hover .form-check-input {
 
 #searchHistoryButton:hover, #searchHistoryButton.active-button {
   background-color: transparent;
-  color: var(--google-green);
+  color: var(--success);
 }
 #searchHistoryButton:hover::after {
-  background-color: var(--google-green);
+  background-color: var(--success);
 }
 #searchHistoryButton.active-button::after {
-  background-color: var(--google-green);
+  background-color: var(--success);
 }
 #searchHistoryButton.active-button:focus-visible {
   background-color: transparent;
-  box-shadow: 0 0 0 4px var(--google-green-500);
+  box-shadow: 0 0 0 4px var(--success-500);
 }
 
 #favoriteListButton:hover, #favoriteListButton.active-button {
   background-color: transparent;
-  color: var(--google-yellow);
+  color: var(--warning);
 }
 #favoriteListButton:hover::after {
-  background-color: var(--google-yellow);
+  background-color: var(--warning);
 }
 #favoriteListButton.active-button::after {
-  background-color: var(--google-yellow);
+  background-color: var(--warning);
 }
 #favoriteListButton.active-button:focus-visible {
   background-color: transparent;
-  box-shadow: 0 0 0 4px var(--google-yellow-500);
+  box-shadow: 0 0 0 4px var(--warning-500);
 }
 
 #deleteListButton:hover, #deleteListButton.active-button {
   background-color: transparent;
-  color: var(--danger-color);
+  color: var(--danger);
 }
 #deleteListButton:hover::after {
-  background-color: var(--danger-color);
+  background-color: var(--danger);
 }
 #deleteListButton.active-button::after {
-  background-color: var(--danger-color);
+  background-color: var(--danger);
 }
 #deleteListButton.active-button:focus-visible {
   background-color: transparent;
-  box-shadow: 0 0 0 4px var(--danger-color-500);
+  box-shadow: 0 0 0 4px var(--danger-500);
 }
 
 #geminiSummaryButton:hover, #geminiSummaryButton.active-button {
   background-color: transparent;
-  color: var(--google-purple);
+  color: var(--purple);
 }
 #geminiSummaryButton:hover::after {
-  background-color: var(--google-purple);
+  background-color: var(--purple);
 }
 #geminiSummaryButton.active-button::after {
-  background-color: var(--google-purple);
+  background-color: var(--purple);
 }
 #geminiSummaryButton.active-button:focus-visible {
   background-color: transparent;
-  box-shadow: 0 0 0 4px var(--google-purple-500);
+  box-shadow: 0 0 0 4px var(--purple-500);
 }
 
 #videoSummaryButton:hover, #videoSummaryButton.active-button {
   background-color: transparent;
-  color: var(--danger-color);
+  color: var(--danger);
 }
 #videoSummaryButton:hover::after {
-  background-color: var(--danger-color);
+  background-color: var(--danger);
 }
 #videoSummaryButton.active-button::after {
-  background-color: var(--danger-color);
+  background-color: var(--danger);
 }
 #videoSummaryButton.active-button:focus-visible {
   background-color: transparent;
-  box-shadow: 0 0 0 4px var(--danger-color-500);
+  box-shadow: 0 0 0 4px var(--danger-500);
 }
 #videoSummaryButton.no-hover-temp:hover {
   background-color: transparent;
-  color: var(--gray-600);
+  color: var(--text-secondary);
 }
 #videoSummaryButton.no-hover-temp:hover::after {
   background-color: transparent;
@@ -487,8 +460,8 @@ li:hover .form-check-input {
 }
 
 .modal-body p:hover {
-  -webkit-text-decoration: var(--border-color) underline;
-          text-decoration: var(--border-color) underline;
+  -webkit-text-decoration: var(--border) underline;
+          text-decoration: var(--border) underline;
 }
 
 .btn-close {
@@ -498,7 +471,7 @@ li:hover .form-check-input {
 }
 
 .premium-only {
-  color: var(--gray-400) !important;
+  color: var(--border) !important;
   pointer-events: none !important;
 }
 
@@ -527,15 +500,15 @@ li:hover .form-check-input {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--gray-400);
+  background: var(--border);
   border-radius: 0.5rem;
 }
 
 /* context menu */
 .context-menu {
-  background-color: var(--background-color);
+  background-color: var(--color-bg);
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   padding: 4px;
 }
 
@@ -543,7 +516,7 @@ li:hover .form-check-input {
   padding: 8px 16px;
 }
 .context-menu-item:hover {
-  color: var(--gray-600);
+  color: var(--text-secondary);
 }
 
 /* animation  */

--- a/Package/css/theme.css
+++ b/Package/css/theme.css
@@ -1,0 +1,90 @@
+:root {
+  --font-ui: "Satoshi-Variable", "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC", system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+
+  --color-bg: #ffffff;
+  --surface-1: #f6fafe;
+  --surface-2: #eff1f3;
+  --border: #dadce0;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+
+  --accent: #4285f4;
+  --focus-ring: var(--accent);
+
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+
+  --purple: #8779cd;
+  --purple-hover: #6c61a4;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1b1e23;
+    --surface-1: #23262d;
+    --surface-2: #2c3036;
+    --border: #3c4043;
+    --text-primary: #e8eaed;
+    --text-secondary: #bdc1c6;
+
+    --accent: #8ab4f8;
+    --focus-ring: var(--accent);
+
+    --danger: #f28b82;
+    --danger-500: #f6b6b2;
+    --danger-bg: #3b2220;
+
+    --success: #81c995;
+    --success-500: #b4dfc4;
+    --success-bg: #1c3526;
+
+    --warning: #fdd663;
+    --warning-500: #fde293;
+    --warning-bg: #3a2e1a;
+
+    --purple: #b39dfa;
+    --purple-hover: #9775d8;
+    --purple-500: #d3bffb;
+    --purple-bg: #2e253a;
+  }
+}
+
+[data-theme="dark"] {
+  --color-bg: #1b1e23;
+  --surface-1: #23262d;
+  --surface-2: #2c3036;
+  --border: #3c4043;
+  --text-primary: #e8eaed;
+  --text-secondary: #bdc1c6;
+
+  --accent: #8ab4f8;
+  --focus-ring: var(--accent);
+
+  --danger: #f28b82;
+  --danger-500: #f6b6b2;
+  --danger-bg: #3b2220;
+
+  --success: #81c995;
+  --success-500: #b4dfc4;
+  --success-bg: #1c3526;
+
+  --warning: #fdd663;
+  --warning-500: #fde293;
+  --warning-bg: #3a2e1a;
+
+  --purple: #b39dfa;
+  --purple-hover: #9775d8;
+  --purple-500: #d3bffb;
+  --purple-bg: #2e253a;
+}

--- a/Package/dist/scripts/theme.js
+++ b/Package/dist/scripts/theme.js
@@ -1,0 +1,41 @@
+(function () {
+  const root = document.documentElement;
+  const toggleId = 'themeToggle';
+
+  function apply(theme) {
+    root.dataset.theme = theme;
+  }
+
+  function systemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function initToggle(theme) {
+    const toggle = document.getElementById(toggleId);
+    if (!toggle) return;
+    toggle.checked = theme === 'dark';
+    toggle.addEventListener('change', () => {
+      const next = toggle.checked ? 'dark' : 'light';
+      apply(next);
+      chrome.storage.sync.set({ theme: next });
+    });
+  }
+
+  function init() {
+    chrome.storage.sync.get('theme', (data) => {
+      const theme = data.theme || systemTheme();
+      apply(theme);
+      initToggle(theme);
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      chrome.storage.sync.get('theme', (data) => {
+        if (!data.theme) {
+          apply(e.matches ? 'dark' : 'light');
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/Package/manifest.json
+++ b/Package/manifest.json
@@ -66,7 +66,7 @@
         "dist/module/appSecret.js",
         "dist/contentScript.js"
       ],
-      "css": ["css/iframe.css"]
+      "css": ["css/theme.css", "css/iframe.css"]
     }
   ],
   "default_locale": "en",
@@ -81,6 +81,7 @@
       "resources": [
         "vendor/fonts/*.woff2",
         "popup.html",
+        "css/theme.css",
         "css/iframe.css",
         "dist/inject.js",
         "dist/ejectLite.js",

--- a/Package/popup.html
+++ b/Package/popup.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="vendor/bootstrap.min.css" />
     <link rel="stylesheet" href="vendor/bootstrap-icons.css" />
     <link rel="stylesheet" href="vendor/satoshi.css" />
+    <link rel="stylesheet" href="css/theme.css" />
     <link rel="stylesheet" href="css/popup.css" />
 </head>
 
@@ -219,6 +220,10 @@
                                 <i class="bi bi-arrow-right"></i>
                             </button>
                         </form>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="themeToggle" />
+                            <label class="form-check-label" for="themeToggle" data-locale="darkModeLabel">Dark mode</label>
+                        </div>
                     </div>
                     <div class="modal-footer d-flex justify-content-start">
                         <p class="text-muted" data-locale="dirNote">Launch a map with directions from the starting address to the highlighted text in the context menu.</p>
@@ -251,6 +256,7 @@
             </div>
         </div>
     </div>
+    <script defer src="dist/scripts/theme.js"></script>
     <script defer src='dist/scripts/menu.js'></script>
     <script defer src='dist/scripts/remove.js'></script>
     <script defer src='dist/scripts/favorite.js'></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "google-maps-extension",
+  "version": "1.0.0",
+  "description": "Build tools for The Maps Express",
+  "type": "module",
+  "scripts": {
+    "contrast": "node tools/contrast-check.js"
+  }
+}

--- a/scss/iframe.scss
+++ b/scss/iframe.scss
@@ -1,19 +1,9 @@
-:root {
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-}
 
 #TMEiframe {
   position: fixed;
   width: 400px;
   height: 480px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   z-index: 10000;
   box-shadow: 0 8px 24px rgba(112, 144, 176, 0.25);
   border-radius: 8px;
@@ -29,14 +19,14 @@
 
 #TMEdrag {
   height: 32px;
-  background-color: var(--gray-300);
+  background-color: var(--surface-2);
   cursor: move;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 0 0 1rem;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border);
 
   &::after {
     content: none !important;
@@ -50,7 +40,7 @@
   div {
     width: 1px;
     height: 8px;
-    background-color: var(--gray-600);
+    background-color: var(--text-secondary);
   }
 }
 
@@ -69,14 +59,14 @@
   svg {
     width: 20px;
     height: 20px;
-    fill: var(--gray-600);
+    fill: var(--text-secondary);
   }
 
   &:hover {
-    background: var(--danger-color);
+    background: var(--danger);
 
     svg {
-      fill: var(--background-color);
+      fill: var(--color-bg);
     }
   }
 

--- a/scss/popup.scss
+++ b/scss/popup.scss
@@ -1,32 +1,3 @@
-:root {
-  --primary-color: #4285f4;
-  --border-color: #dee2e6;
-  --danger-color: #db4437;
-  --danger-color-500: #eda19b;
-  --danger-color-bg: #fff8f7;
-  --background-color: #ffffff;
-  --gray-800: #202833;
-  --gray-600: #70757a;
-  --gray-400: #dadce0;
-  --gray-300: #eff1f3;
-  --gray-200: #f6fafe;
-  --google-green: #0f9d58;
-  --google-green-500: #87cdab;
-  --google-green-bg: #f7fffb;
-  --google-yellow: #f4b400;
-  --google-yellow-500: #f9d980;
-  --google-yellow-bg: #fffdf7;
-  --google-purple-hover: #6c61a4;
-  --google-purple: #8779cd;
-  --google-purple-500: #c3bce6;
-  --google-purple-bg: #fafafd;
-
-  /* TC + Emoji safe */
-  --ui-font: "Satoshi-Variable",
-    "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC",
-    system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
-}
 
 html,
 body {
@@ -34,8 +5,9 @@ body {
   box-sizing: border-box;
   overflow-y: auto;
   overflow-x: hidden;
-  color: var(--gray-800);
-  font-family: var(--ui-font);
+  background-color: var(--color-bg);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
   font-weight: 400;
 }
 
@@ -44,7 +16,7 @@ body {
 .brand {
   border-top-left-radius: 2rem;
   border-bottom-left-radius: 2rem;
-  background-color: var(--background-color);
+  background-color: var(--color-bg);
 }
 
 .input-group-prepend {
@@ -55,17 +27,17 @@ body {
   border-left: 0rem;
   border-top-right-radius: 2rem;
   border-bottom-right-radius: 2rem;
-  color: var(--gray-800);
+  color: var(--text-primary);
 
   &::placeholder {
-    color: var(--gray-600);
+    color: var(--text-secondary);
     font-weight: 300;
   }
 
   &:focus {
-    color: var(--gray-600);
-    background-color: var(--background-color);
-    border-color: var(--border-color);
+    color: var(--text-secondary);
+    background-color: var(--color-bg);
+    border-color: var(--border);
     outline: none;
     box-shadow: none;
 
@@ -84,8 +56,8 @@ body {
   right: 0.75rem;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--gray-800);
-  background-color: var(--background-color);
+  color: var(--text-primary);
+  background-color: var(--color-bg);
   width: 2rem;
   height: 2rem;
   cursor: pointer;
@@ -103,14 +75,14 @@ body {
   padding-left: 1rem;
 
   &::placeholder {
-    color: var(--gray-600);
+    color: var(--text-secondary);
     font-weight: 300;
   }
 
   &:focus {
-    color: var(--gray-600);
-    background-color: var(--background-color);
-    border-color: var(--border-color);
+    color: var(--text-secondary);
+    background-color: var(--color-bg);
+    border-color: var(--border);
     outline: none;
     box-shadow: none;
 
@@ -125,7 +97,7 @@ body {
   right: 1.5rem;
   top: 50%;
   transform: translateY(-50%);
-  background-color: var(--google-purple);
+  background-color: var(--purple);
   color: white;
   width: 2rem;
   height: 2rem;
@@ -137,7 +109,7 @@ body {
 }
 
 .modal-footer p a {
-  color: var(--google-purple);
+  color: var(--purple);
   font-weight: 700;
   text-decoration: none;
 }
@@ -149,14 +121,14 @@ body {
   padding-left: 1rem;
 
   &::placeholder {
-    color: var(--gray-600);
+    color: var(--text-secondary);
     font-weight: 300;
   }
 
   &:focus {
-    color: var(--gray-600);
-    background-color: var(--background-color);
-    border-color: var(--border-color);
+    color: var(--text-secondary);
+    background-color: var(--color-bg);
+    border-color: var(--border);
     outline: none;
     box-shadow: none;
 
@@ -171,7 +143,7 @@ body {
   right: 1.5rem;
   top: 50%;
   transform: translateY(-50%);
-  background-color: var(--primary-color);
+  background-color: var(--accent);
   color: white;
   width: 2rem;
   height: 2rem;
@@ -185,7 +157,7 @@ body {
 /* list-group-item */
 
 .list-group-item {
-  color: var(--gray-600);
+  color: var(--text-secondary);
   max-width: 100%;
   cursor: pointer;
 
@@ -199,28 +171,28 @@ body {
 }
 
 .history-list:hover {
-  color: var(--google-green);
-  background-color: var(--google-green-bg);
-  border: 1px solid var(--google-green) !important;
+  color: var(--success);
+  background-color: var(--success-bg);
+  border: 1px solid var(--success) !important;
 }
 
 .favorite-list:hover {
-  color: var(--google-yellow);
-  background-color: var(--google-yellow-bg);
-  border: 1px solid var(--google-yellow) !important;
+  color: var(--warning);
+  background-color: var(--warning-bg);
+  border: 1px solid var(--warning) !important;
 }
 
 .delete-list:hover,
 .checked-list {
-  color: var(--danger-color);
-  background-color: var(--danger-color-bg);
-  border: 1px solid var(--danger-color) !important;
+  color: var(--danger);
+  background-color: var(--danger-bg);
+  border: 1px solid var(--danger) !important;
 }
 
 .summary-list:hover {
-  color: var(--google-purple);
-  background-color: var(--google-purple-bg);
-  border: 1px solid var(--google-purple) !important;
+  color: var(--purple);
+  background-color: var(--purple-bg);
+  border: 1px solid var(--purple) !important;
 }
 
 #searchHistoryList,
@@ -282,29 +254,29 @@ li {
 /* checkbox */
 
 .form-check-input {
-  border-color: var(--border-color);
+  border-color: var(--border);
   min-width: 1rem;
   min-height: 1rem;
   margin-top: 0rem;
 
   &:focus-visible {
-    box-shadow: 0 0 0 0px var(--danger-color-500);
-    border-color: var(--danger-color);
+    box-shadow: 0 0 0 0px var(--danger-500);
+    border-color: var(--danger);
   }
 
   &:focus {
-    box-shadow: 0 0 0 0px var(--danger-color-500);
-    border-color: var(--border-color);
+    box-shadow: 0 0 0 0px var(--danger-500);
+    border-color: var(--border);
   }
 
   &:checked {
-    background-color: var(--danger-color);
-    border-color: var(--danger-color);
+    background-color: var(--danger);
+    border-color: var(--danger);
   }
 }
 
 li:hover .form-check-input {
-  border-color: var(--danger-color-500);
+  border-color: var(--danger-500);
 }
 
 /* buttons */
@@ -314,70 +286,70 @@ li:hover .form-check-input {
   padding-left: 0.75rem;
 
   &:hover {
-    color: var(--gray-800) !important;
+    color: var(--text-primary) !important;
   }
 }
 
 .btn-light {
-  color: var(--gray-600);
-  background-color: var(--gray-300);
-  border: 1px solid var(--gray-300);
+  color: var(--text-secondary);
+  background-color: var(--surface-2);
+  border: 1px solid var(--surface-2);
 
   &:hover {
-    border: 1px solid var(--gray-300);
+    border: 1px solid var(--surface-2);
   }
 }
 
 .btn-maps {
-  background-color: var(--primary-color);
-  border: 1px solid var(--primary-color);
+  background-color: var(--accent);
+  border: 1px solid var(--accent);
 }
 
 .btn-delete {
-  background-color: var(--danger-color);
-  border: 1px solid var(--danger-color);
+  background-color: var(--danger);
+  border: 1px solid var(--danger);
 }
 
 #clearButton,
 #cancelButton,
 #clearButtonSummary {
-  color: var(--gray-600);
+  color: var(--text-secondary);
 }
 
 #clearButton:hover,
 #clearButtonSummary:hover {
-  background-color: var(--danger-color);
-  border: 1px solid var(--danger-color);
-  color: var(--background-color);
+  background-color: var(--danger);
+  border: 1px solid var(--danger);
+  color: var(--color-bg);
 }
 
 .btn-send {
-  background-color: var(--google-purple);
-  border: 1px solid var(--google-purple);
-  color: var(--background-color);
+  background-color: var(--purple);
+  border: 1px solid var(--purple);
+  color: var(--color-bg);
 
   &:hover {
-    background-color: var(--google-purple-hover);
-    border: 1px solid var(--google-purple-hover);
-    color: var(--background-color);
+    background-color: var(--purple-hover);
+    border: 1px solid var(--purple-hover);
+    color: var(--color-bg);
   }
 
   &:active {
-    background-color: var(--google-purple-hover) !important;
-    border: 1px solid var(--google-purple-hover) !important;
-    color: var(--background-color) !important;
+    background-color: var(--purple-hover) !important;
+    border: 1px solid var(--purple-hover) !important;
+    color: var(--color-bg) !important;
   }
 
   &:focus-visible {
-    background-color: var(--google-purple);
-    box-shadow: 0 0 0 4px var(--google-purple-500);
-    color: var(--background-color);
+    background-color: var(--purple);
+    box-shadow: 0 0 0 4px var(--purple-500);
+    color: var(--color-bg);
   }
 
   &:disabled {
-    background-color: var(--google-purple);
-    border: 1px solid var(--google-purple);
-    color: var(--background-color);
+    background-color: var(--purple);
+    border: 1px solid var(--purple);
+    color: var(--color-bg);
     opacity: 0.65;
   }
 }
@@ -388,7 +360,7 @@ li:hover .form-check-input {
 #geminiSummaryButton,
 #videoSummaryButton {
   border: none;
-  color: var(--gray-600);
+  color: var(--text-secondary);
   position: relative;
 }
 
@@ -416,21 +388,21 @@ li:hover .form-check-input {
   &:hover,
   &.active-button {
     background-color: transparent;
-    color: var(--google-green);
+    color: var(--success);
   }
 
   &:hover::after {
-    background-color: var(--google-green);
+    background-color: var(--success);
   }
 
   &.active-button {
     &::after {
-      background-color: var(--google-green);
+      background-color: var(--success);
     }
 
     &:focus-visible {
       background-color: transparent;
-      box-shadow: 0 0 0 4px var(--google-green-500);
+      box-shadow: 0 0 0 4px var(--success-500);
     }
   }
 }
@@ -440,21 +412,21 @@ li:hover .form-check-input {
   &:hover,
   &.active-button {
     background-color: transparent;
-    color: var(--google-yellow);
+    color: var(--warning);
   }
 
   &:hover::after {
-    background-color: var(--google-yellow);
+    background-color: var(--warning);
   }
 
   &.active-button {
     &::after {
-      background-color: var(--google-yellow);
+      background-color: var(--warning);
     }
 
     &:focus-visible {
       background-color: transparent;
-      box-shadow: 0 0 0 4px var(--google-yellow-500);
+      box-shadow: 0 0 0 4px var(--warning-500);
     }
   }
 }
@@ -464,21 +436,21 @@ li:hover .form-check-input {
   &:hover,
   &.active-button {
     background-color: transparent;
-    color: var(--danger-color);
+    color: var(--danger);
   }
 
   &:hover::after {
-    background-color: var(--danger-color);
+    background-color: var(--danger);
   }
 
   &.active-button {
     &::after {
-      background-color: var(--danger-color);
+      background-color: var(--danger);
     }
 
     &:focus-visible {
       background-color: transparent;
-      box-shadow: 0 0 0 4px var(--danger-color-500);
+      box-shadow: 0 0 0 4px var(--danger-500);
     }
   }
 }
@@ -488,21 +460,21 @@ li:hover .form-check-input {
   &:hover,
   &.active-button {
     background-color: transparent;
-    color: var(--google-purple);
+    color: var(--purple);
   }
 
   &:hover::after {
-    background-color: var(--google-purple);
+    background-color: var(--purple);
   }
 
   &.active-button {
     &::after {
-      background-color: var(--google-purple);
+      background-color: var(--purple);
     }
 
     &:focus-visible {
       background-color: transparent;
-      box-shadow: 0 0 0 4px var(--google-purple-500);
+      box-shadow: 0 0 0 4px var(--purple-500);
     }
   }
 }
@@ -512,28 +484,28 @@ li:hover .form-check-input {
   &:hover,
   &.active-button {
     background-color: transparent;
-    color: var(--danger-color);
+    color: var(--danger);
   }
 
   &:hover::after {
-    background-color: var(--danger-color);
+    background-color: var(--danger);
   }
 
   &.active-button {
     &::after {
-      background-color: var(--danger-color);
+      background-color: var(--danger);
     }
 
     &:focus-visible {
       background-color: transparent;
-      box-shadow: 0 0 0 4px var(--danger-color-500);
+      box-shadow: 0 0 0 4px var(--danger-500);
     }
   }
 
   &.no-hover-temp {
     &:hover {
       background-color: transparent;
-      color: var(--gray-600);
+      color: var(--text-secondary);
     }
 
     &:hover::after {
@@ -558,7 +530,7 @@ li:hover .form-check-input {
 }
 
 .modal-body p:hover {
-  text-decoration: var(--border-color) underline;
+  text-decoration: var(--border) underline;
 }
 
 .btn-close {
@@ -568,7 +540,7 @@ li:hover .form-check-input {
 }
 
 .premium-only {
-  color: var(--gray-400) !important;
+  color: var(--border) !important;
   pointer-events: none !important;
 }
 
@@ -599,16 +571,16 @@ li:hover .form-check-input {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--gray-400);
+  background: var(--border);
   border-radius: 0.5rem;
 }
 
 /* context menu */
 
 .context-menu {
-  background-color: var(--background-color);
+  background-color: var(--color-bg);
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   padding: 4px;
 }
 
@@ -616,7 +588,7 @@ li:hover .form-check-input {
   padding: 8px 16px;
 
   &:hover {
-    color: var(--gray-600);
+    color: var(--text-secondary);
   }
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -1,0 +1,90 @@
+:root {
+  --font-ui: "Satoshi-Variable", "PingFang TC", "Microsoft JhengHei UI", "Noto Sans TC", system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+
+  --color-bg: #ffffff;
+  --surface-1: #f6fafe;
+  --surface-2: #eff1f3;
+  --border: #dadce0;
+  --text-primary: #202833;
+  --text-secondary: #70757a;
+
+  --accent: #4285f4;
+  --focus-ring: var(--accent);
+
+  --danger: #db4437;
+  --danger-500: #eda19b;
+  --danger-bg: #fff8f7;
+
+  --success: #0f9d58;
+  --success-500: #87cdab;
+  --success-bg: #f7fffb;
+
+  --warning: #f4b400;
+  --warning-500: #f9d980;
+  --warning-bg: #fffdf7;
+
+  --purple: #8779cd;
+  --purple-hover: #6c61a4;
+  --purple-500: #c3bce6;
+  --purple-bg: #fafafd;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1b1e23;
+    --surface-1: #23262d;
+    --surface-2: #2c3036;
+    --border: #3c4043;
+    --text-primary: #e8eaed;
+    --text-secondary: #bdc1c6;
+
+    --accent: #8ab4f8;
+    --focus-ring: var(--accent);
+
+    --danger: #f28b82;
+    --danger-500: #f6b6b2;
+    --danger-bg: #3b2220;
+
+    --success: #81c995;
+    --success-500: #b4dfc4;
+    --success-bg: #1c3526;
+
+    --warning: #fdd663;
+    --warning-500: #fde293;
+    --warning-bg: #3a2e1a;
+
+    --purple: #b39dfa;
+    --purple-hover: #9775d8;
+    --purple-500: #d3bffb;
+    --purple-bg: #2e253a;
+  }
+}
+
+[data-theme="dark"] {
+  --color-bg: #1b1e23;
+  --surface-1: #23262d;
+  --surface-2: #2c3036;
+  --border: #3c4043;
+  --text-primary: #e8eaed;
+  --text-secondary: #bdc1c6;
+
+  --accent: #8ab4f8;
+  --focus-ring: var(--accent);
+
+  --danger: #f28b82;
+  --danger-500: #f6b6b2;
+  --danger-bg: #3b2220;
+
+  --success: #81c995;
+  --success-500: #b4dfc4;
+  --success-bg: #1c3526;
+
+  --warning: #fdd663;
+  --warning-500: #fde293;
+  --warning-bg: #3a2e1a;
+
+  --purple: #b39dfa;
+  --purple-hover: #9775d8;
+  --purple-500: #d3bffb;
+  --purple-bg: #2e253a;
+}

--- a/tools/contrast-check.js
+++ b/tools/contrast-check.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+
+function parseVars(block) {
+  const vars = {};
+  block.replace(/--([\w-]+):\s*([^;]+);/g, (_, k, v) => {
+    vars[`--${k}`] = v.trim();
+  });
+  return vars;
+}
+
+const css = fs.readFileSync('Package/css/theme.css', 'utf8');
+const lightBlock = css.match(/:root \{([\s\S]*?)\}/)[1];
+const darkBlock = css.match(/\[data-theme="dark"\] \{([\s\S]*?)\}/)[1];
+const light = parseVars(lightBlock);
+const dark = parseVars(darkBlock);
+
+function luminance(hex) {
+  const rgb = hex.replace('#','').match(/.{2}/g).map(h=>parseInt(h,16)/255);
+  const a = rgb.map(v=>{ v=v<=0.03928? v/12.92: Math.pow((v+0.055)/1.055,2.4); return v;});
+  return 0.2126*a[0]+0.7152*a[1]+0.0722*a[2];
+}
+function contrast(c1,c2){
+  const L1=luminance(c1); const L2=luminance(c2);
+  return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);
+}
+const pairs=[
+  ['--text-primary','--color-bg'],
+  ['--text-secondary','--color-bg'],
+  ['--accent','--color-bg'],
+  ['--danger','--color-bg']
+];
+for(const [fg,bg] of pairs){
+  const ratioL=contrast(light[fg],light[bg]).toFixed(2);
+  const ratioD=contrast(dark[fg],dark[bg]).toFixed(2);
+  console.log(`${fg} on ${bg}: light ${ratioL}, dark ${ratioD}`);
+}


### PR DESCRIPTION
## Summary
- introduce semantic theme tokens and comfortable dark palette
- implement CSP-safe theme toggle with chrome.storage.sync
- add contrast check script for palette verification

## Testing
- `node tools/contrast-check.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b147634832489250f0aced98607