### PR TITLE
fix: handle summarize failures instead of hanging the popup

### DIFF
--- a/Package/dist/background.js
+++ b/Package/dist/background.js
@@ -485,9 +485,14 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   }
 
   if (request.action === "summarizeVideo" && request.text) {
-    getApiKey().then((apiKey) => {
-      callApi(geminiPrompts.summary, request.text, apiKey, sendResponse);
-    });
+    getApiKey()
+      .then((apiKey) => {
+        callApi(geminiPrompts.summary, request.text, apiKey, sendResponse);
+      })
+      .catch((err) => {
+        // Without this the popup would wait forever on a missing API key
+        sendResponse({ error: err.message });
+      });
     return true; // Will respond asynchronously
   }
 });

--- a/Package/dist/components/gemini.js
+++ b/Package/dist/components/gemini.js
@@ -368,8 +368,11 @@ class Gemini {
     chrome.runtime.sendMessage(
       { action: "summarizeApi", text: content, apiKey: apiKey, url: url },
       (response) => {
-        if (response.error) {
-          responseField.value = `API Error: ${response.error}`;
+        // response is undefined when the message channel closes early
+        // (e.g. the service worker was killed); treat it as an error so
+        // the send button is re-enabled instead of throwing here.
+        if (!response || response.error) {
+          responseField.value = `API Error: ${response?.error || "No response from background"}`;
           this.ResponseErrorMsg(response);
         } else {
           responseField.value = response;

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -983,6 +983,24 @@ describe("background.js", () => {
       expect(getApiKey).toHaveBeenCalled();
     });
 
+    test("should respond with an error when summarizeVideo has no API key", async () => {
+      const { getApiKey } = require("../Package/dist/hooks/backgroundState.js");
+      getApiKey.mockRejectedValueOnce(new Error("No API key found. Please provide one."));
+      const sendResponse = jest.fn();
+      const request = {
+        action: "summarizeVideo",
+        text: "https://youtube.com/video",
+      };
+
+      listeners.onMessage[GEMINI_API_LISTENER](request, {}, sendResponse);
+
+      await flushPromises();
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        error: "No API key found. Please provide one.",
+      });
+    });
+
     test("should handle organizeLocations action", async () => {
       const sendResponse = jest.fn();
       const request = {

--- a/tests/gemini.test.js
+++ b/tests/gemini.test.js
@@ -1213,6 +1213,21 @@ describe("Gemini Component", () => {
       expect(sendButton.disabled).toBe(false);
     });
 
+    test("should re-enable send button when response is undefined", async () => {
+      chrome.runtime.sendMessage.mockImplementation((msg, callback) => {
+        if (callback) callback(undefined);
+      });
+
+      sendButton.disabled = true;
+      geminiInstance.summarizeContent("content", "api-key", "https://example.com");
+
+      await wait(50);
+
+      expect(responseField.value).toContain("API Error:");
+      expect(geminiInstance.ResponseErrorMsg).toHaveBeenCalled();
+      expect(sendButton.disabled).toBe(false);
+    });
+
     test("should handle HTML parsing error", async () => {
       const invalidResponse = "Not valid HTML";
       chrome.runtime.sendMessage.mockImplementation((msg, callback) => {


### PR DESCRIPTION
## 問題

摘要流程有兩條失敗路徑會讓 popup 卡死:

1. **`background.js` 的 `summarizeVideo`**:`getApiKey()` 沒有 `.catch`。沒設 API key 時 promise reject,`sendResponse` 永遠不被呼叫 → popup 載入動畫永遠轉,service worker 留下 unhandled rejection。
2. **`gemini.js` 的 `summarizeContent`**:callback 直接讀 `response.error`,當訊息通道提早關閉(SW 被砍)時 `response` 是 `undefined` → TypeError,後面的 `sendButton.disabled = false` 不會執行,**送出按鈕永久停用**直到重開 popup。

## 修法

- `summarizeVideo` 補 `.catch(err => sendResponse({ error: err.message }))`
- `summarizeContent` 改為 `if (!response || response.error)`,無回應也走錯誤 UI,按鈕保證恢復

## 測試

- 全部 21 套件 / 1225 個測試通過
- 新增 2 個回歸測試:無 API key 時 `summarizeVideo` 回覆 `{error}`;response 為 undefined 時送出按鈕會恢復

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_