### PR TITLE
fix: stop exposing the AES key through getWarmState

### DIFF
--- a/Package/dist/background.js
+++ b/Package/dist/background.js
@@ -646,7 +646,11 @@ chrome.tabs.onActivated.addListener(() => {
 // 2) Fast message responder for popup
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   if (request.action === "getWarmState") {
-    ensureWarm().then(() => sendResponse(getCache()));
+    ensureWarm().then(() => {
+      // Never ship AES key material outside the service worker
+      const { aesKey, ...warmState } = getCache();
+      sendResponse(warmState);
+    });
     return true;
   } else if (request.action === "getApiKey") {
     getApiKey().then((apiKey) => sendResponse({ apiKey }));

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1235,6 +1235,28 @@ describe("background.js", () => {
       expect(sendResponse).toHaveBeenCalledWith(mockCache);
     });
 
+    test("should not expose aesKey through getWarmState", async () => {
+      const { ensureWarm, getCache } = require("../Package/dist/hooks/backgroundState.js");
+      const sendResponse = jest.fn();
+      const request = { action: "getWarmState" };
+
+      ensureWarm.mockResolvedValue({});
+      getCache.mockReturnValue({
+        geminiApiKey: "decrypted-key",
+        aesKey: { kty: "oct", k: "secret-jwk-material" },
+        historyMax: 10,
+      });
+
+      listeners.onMessage[STATE_QUERIES_LISTENER](request, {}, sendResponse);
+
+      await flushPromises();
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        geminiApiKey: "decrypted-key",
+        historyMax: 10,
+      });
+    });
+
     test("should handle getApiKey action", async () => {
       const { getApiKey } = require("../Package/dist/hooks/backgroundState.js");
       const sendResponse = jest.fn();


### PR DESCRIPTION
## 問題

`backgroundState.js` 的 `DEFAULTS` 包含 `aesKey`,所以 `ensureWarm()` 會把「用來加密 Gemini API key 的 AES-GCM 金鑰(可匯出的 JWK)」一起載入模組快取;而 `getWarmState` 處理器把**整個快取**(解密後的 API key + AES 金鑰)`sendResponse` 給任何發訊的 extension context。popup 只需要使用者層級的欄位,金鑰材料完全不該離開 service worker。

## 修法

`getWarmState` 回應前以解構剔除 `aesKey` 再送出。

## 測試

- 全部 21 套件 / 1224 個測試通過
- 新增回歸測試:`getWarmState` 回應不得包含 `aesKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_