### PR TITLE
fix: narrow web_accessible_resources to what pages actually load

### DIFF
--- a/Package/manifest.json
+++ b/Package/manifest.json
@@ -79,23 +79,7 @@
   "web_accessible_resources": [
     {
       "matches": ["<all_urls>"],
-      "resources": [
-        "vendor/fonts/*.woff2",
-        "popup.html",
-        "css/iframe.css",
-        "dist/inject.js",
-        "dist/ejectLite.js",
-        "dist/checkStatus.js",
-        "dist/utils/ExtPay.module.js",
-        "dist/utils/browser-polyfill.js",
-        "dist/utils/crypto.js",
-        "dist/utils/prompt.js",
-        "dist/utils/theme.js",
-        "dist/utils/analytics.js",
-        "dist/utils/analytics.module.js",
-        "dist/hooks/backgroundState.js",
-        "dist/hooks/popupState.js"
-      ]
+      "resources": ["vendor/fonts/*.woff2", "popup.html", "css/iframe.css"]
     }
   ]
 }


### PR DESCRIPTION
## 問題

`web_accessible_resources` 對 `<all_urls>` 開放了 14 項資源,但其中 11 個 JS 檔案從來不需要 web accessibility。每一項 WAR 都是任意網站可以探測「使用者裝了這個擴充功能」的指紋點,也擴大攻擊面。

## 分析

真正會被網頁 origin 載入的只有:
- `popup.html` — 由 `inject.js` 以 iframe 嵌入宿主頁面
- `css/iframe.css` 與字型 — 保守保留

可以移除的(全部可證明不需要):
- `inject.js` / `ejectLite.js` / `checkStatus.js`:用 `chrome.scripting.executeScript({files})` 注入,不走 WAR
- `ExtPay.module.js`、`browser-polyfill.js`、`prompt.js`、`analytics*.js`、`hooks/*`:service worker 的 ES import 或 popup.html 的 `<script>` 標籤——都是 extension origin
- `crypto.js`:由 modal.js 在 popup 文件內 dynamic import,popup 即使被 iframe 嵌入仍是 extension origin

## 測試

全部 21 套件 / 1223 個測試通過;manifest JSON 驗證通過。建議 merge 前手動驗證一次 iframe 注入流程(點擊工具列圖示)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_