### PR TITLE
fix: make favorite CSV import round-trip the export format

### DIFF
--- a/Package/dist/components/favorite.js
+++ b/Package/dist/components/favorite.js
@@ -45,13 +45,14 @@ class Favorite {
           const fileContent = event.target.result;
 
           if (fileContent && fileContent.length > 0) {
-            // Parse CSV content
-            const rows = fileContent
-              .split("\n")
-              .map((row) => row.trim())
-              .filter((row) => row.length > 0);
-            importedData = rows.slice(1).map((row) => row.replace(/,$/, ""));
-            favoriteEmptyMessage.style.display = "none";
+            // Parse CSV rows (quote-aware, so exported names containing
+            // commas, quotes, or newlines round-trip unchanged)
+            const rows = this.parseCSV(fileContent);
+            importedData = rows
+              .slice(1) // drop the "name" header row
+              .map((row) => (row[0] || "").trim())
+              .filter((name) => name.length > 0);
+            favoriteEmptyMessage.style.display = importedData.length ? "none" : "block";
           } else {
             favoriteEmptyMessage.style.display = "block";
           }
@@ -117,6 +118,54 @@ class Favorite {
     favoriteListContainer.addEventListener("contextmenu", (event) => {
       ContextMenuUtil.createContextMenu(event, favoriteListContainer);
     });
+  }
+
+  // Minimal RFC 4180-style parser: handles quoted fields with embedded
+  // commas, doubled quotes, and newlines — the same cases escapeCSV in the
+  // export path produces.
+  parseCSV(content) {
+    const rows = [];
+    let row = [];
+    let field = "";
+    let inQuotes = false;
+
+    for (let i = 0; i < content.length; i++) {
+      const ch = content[i];
+
+      if (inQuotes) {
+        if (ch === '"') {
+          if (content[i + 1] === '"') {
+            field += '"';
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          field += ch;
+        }
+      } else if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        row.push(field);
+        field = "";
+      } else if (ch === "\n" || ch === "\r") {
+        if (ch === "\r" && content[i + 1] === "\n") i++;
+        row.push(field);
+        rows.push(row);
+        row = [];
+        field = "";
+      } else {
+        field += ch;
+      }
+    }
+
+    if (field !== "" || row.length > 0) {
+      row.push(field);
+      rows.push(row);
+    }
+
+    // Drop rows that are entirely empty (e.g. blank lines)
+    return rows.filter((r) => r.some((f) => f.trim().length > 0));
   }
 
   createFavoriteIcon(itemName, favoriteList) {

--- a/tests/favorite.test.js
+++ b/tests/favorite.test.js
@@ -288,6 +288,21 @@ describe("Favorite Component", () => {
         expect(data.favoriteList).toEqual(["Location 1", "Location 2"]);
       });
 
+      test("should round-trip names containing commas, quotes, and newlines", async () => {
+        // Exactly what the export path produces for these names
+        const csv = 'name\n"Cafe, Downtown"\n"The ""Best"" Bar"\n"Line1\nLine2"\n';
+        mockFileUpload(fileInput, csv);
+
+        const storageSetPromise = new Promise((resolve) => {
+          mockChromeStorage({}, (data) => resolve(data));
+        });
+
+        fileInput.dispatchEvent(new Event("change"));
+
+        const data = await storageSetPromise;
+        expect(data.favoriteList).toEqual(["Cafe, Downtown", 'The "Best" Bar', "Line1\nLine2"]);
+      });
+
       test("should return early if no file selected", () => {
         Object.defineProperty(fileInput, "files", {
           value: [],


### PR DESCRIPTION
## 問題

匯出端(`escapeCSV`)會把含逗號/引號/換行的名稱包成 `"..."`,但匯入端只做 `split("\n")` + 去尾逗號,完全不解析引號。使用者「匯出備份 → 匯入還原」會拿到損壞的資料:

- `Cafe, Downtown` 變成帶字面引號的 `"Cafe, Downtown"`
- 名稱含換行會被拆成兩筆錯誤項目

## 修法

在 `favorite.js` 加一個最小的 RFC 4180 風格 quote-aware 解析器(約 40 行,正好涵蓋匯出端會產生的三種跳脫情境),匯入時取第一欄。保留既有行為:去 header 列、trim、忽略空行、相容舊格式的尾逗號。

## 測試

- 全部 21 套件 / 1224 個測試通過(既有匯入測試不變)
- 新增 round-trip 回歸測試:含逗號、雙引號、換行的名稱經匯出格式再匯入後原樣還原

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_