### PR TITLE
fix: clean up inject.js document/window listeners on eject

### DIFF
--- a/Package/dist/inject.js
+++ b/Package/dist/inject.js
@@ -11,6 +11,17 @@ window.TME = {
     const defaultX = window.innerWidth - 480;
     const defaultY = 50;
 
+    // Collects every document/window listener registered below so eject()
+    // can remove them all; otherwise each on/off toggle leaks a set. Kept on
+    // window (like TMEhasRun) so a re-injected script can still abort the
+    // previous instance's listeners.
+    if (window.TMEcleanup) {
+      window.TMEcleanup.abort();
+    }
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    window.TMEcleanup = abortController;
+
     let iframeContainer = document.createElement("div");
     iframeContainer.id = "TMEiframe";
     iframeContainer.style.left = defaultX + "px";
@@ -56,11 +67,15 @@ window.TME = {
     });
 
     // Close by Esc key
-    document.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") {
-        TME.eject();
-      }
-    });
+    document.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key === "Escape") {
+          TME.eject();
+        }
+      },
+      { signal }
+    );
 
     draggableBar.appendChild(linesContainer);
     draggableBar.appendChild(closeButton);
@@ -96,12 +111,16 @@ window.TME = {
     };
 
     // Adjust iframe left position when the document width becomes smaller
-    window.addEventListener("resize", () => {
-      const coordsX = iframeContainer.getBoundingClientRect().left;
-      const adjustedX = Math.min(coordsX, window.innerWidth - iframeContainer.offsetWidth - 40);
+    window.addEventListener(
+      "resize",
+      () => {
+        const coordsX = iframeContainer.getBoundingClientRect().left;
+        const adjustedX = Math.min(coordsX, window.innerWidth - iframeContainer.offsetWidth - 40);
 
-      iframeContainer.style.left = `${adjustedX}px`;
-    });
+        iframeContainer.style.left = `${adjustedX}px`;
+      },
+      { signal }
+    );
 
     // Create a custom resizer
     const resizer = document.createElement("div");
@@ -124,8 +143,10 @@ window.TME = {
       event.preventDefault();
     });
 
-    document.addEventListener("mousemove", (event) => {
-      if (isResizing) {
+    document.addEventListener(
+      "mousemove",
+      (event) => {
+        if (!isResizing) return;
         let currentMouseY = event.clientY;
         let newHeight = currentMouseY - iframeContainer.getBoundingClientRect().top;
         const mouseDirection = currentMouseY <= initialMouseY ? "up" : "down";
@@ -152,19 +173,28 @@ window.TME = {
           type: "resize",
           heightChange: heightChange,
         });
-      }
-    });
+      },
+      { signal }
+    );
 
-    document.addEventListener("mouseup", () => {
-      if (isResizing) {
-        iframeContainer.style.transition = "width 0.3s ease-in-out, height 0.3s ease-in-out";
-      }
-      isResizing = false;
-    });
+    document.addEventListener(
+      "mouseup",
+      () => {
+        if (isResizing) {
+          iframeContainer.style.transition = "width 0.3s ease-in-out, height 0.3s ease-in-out";
+        }
+        isResizing = false;
+      },
+      { signal }
+    );
 
     return iframe;
   },
   eject: function () {
+    if (window.TMEcleanup) {
+      window.TMEcleanup.abort();
+      window.TMEcleanup = null;
+    }
     let iframeContainer = document.getElementById("TMEiframe");
     if (iframeContainer) {
       iframeContainer.remove();

--- a/tests/inject.test.js
+++ b/tests/inject.test.js
@@ -420,6 +420,20 @@ describe("inject.js - TME Module", () => {
       // Should not throw
       expect(() => TME.eject()).not.toThrow();
     });
+
+    test("should remove document listeners so they do not accumulate", () => {
+      TME.eject();
+
+      const ejectSpy = jest.spyOn(TME, "eject");
+      const escapeEvent = new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+      });
+      document.dispatchEvent(escapeEvent);
+
+      // The Escape listener registered by setup() must be gone after eject()
+      expect(ejectSpy).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================================================


### PR DESCRIPTION
## 問題

`TME.eject()` 只移除 iframe 容器,`document` 上的 `keydown`(Esc)/`mousemove`/`mouseup` 和 `window` 的 `resize` 監聽器全部留在頁面上;下次點擊圖示 `inject.js` 重跑又註冊一整組。在同一頁反覆開關,監聽器無上限累積:按一次 Esc 會觸發 N 個殘留 handler,每次滑鼠移動跑 N 次 layout 讀取。

## 修法

- `setup()` 建立一個 `AbortController`,所有 document/window 監聽器都帶 `{ signal }` 註冊
- controller 存在 `window.TMEcleanup`(比照既有的 `TMEhasRun` 慣例),即使腳本被重新注入、`TME` 物件被整個替換,新實例仍能中止前一個實例的監聽器
- `eject()` 與 `setup()` 開頭都會 abort

## 測試

- 全部 21 套件 / 1224 個測試通過
- 新增回歸測試:`eject()` 後按 Esc 不得再觸發任何 handler(這個測試順帶抓到了「controller 存在 TME 物件上會因重注入而孤兒化」的問題,因此改存 window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_