### PR TITLE
fix: guard against missing active tab in tabs.query callbacks

### DIFF
--- a/Package/dist/background.js
+++ b/Package/dist/background.js
@@ -151,6 +151,8 @@ chrome.commands.onCommand.addListener((command) => {
   Analytics.trackShortcut(command);
 
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    // No active tab when focus is on devtools or a detached window
+    if (!tabs.length) return;
     const url = tabs[0].url;
     const tabId = tabs[0].id;
     if (url && url.startsWith("http")) {
@@ -565,6 +567,7 @@ chrome.action.onClicked.addListener(meow);
 
 function meow() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (!tabs.length) return;
     chrome.scripting.executeScript(
       {
         target: { tabId: tabs[0].id },

--- a/Package/dist/components/gemini.js
+++ b/Package/dist/components/gemini.js
@@ -93,7 +93,12 @@ class Gemini {
       if (isVideoSummaryActive) {
         // Use video summary functionality
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-          if (!tabs.length) return;
+          if (!tabs.length) {
+            // No active tab (e.g. focus on devtools/detached window): restore controls
+            sendButton.disabled = false;
+            clearButtonSummary.disabled = false;
+            return;
+          }
           this.summarizeFromGeminiVideoUnderstanding(tabs[0].url);
         });
       } else {
@@ -305,7 +310,12 @@ class Gemini {
       const apiKey = res ? res.apiKey : "";
 
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        if (!tabs.length) return;
+        if (!tabs.length) {
+          // No active tab (e.g. focus on devtools/detached window): restore controls
+          sendButton.disabled = false;
+          clearButtonSummary.disabled = false;
+          return;
+        }
         chrome.tabs.sendMessage(tabs[0].id, { message: "ping" }, (response) => {
           if (chrome.runtime.lastError) {
             summaryListContainer.innerHTML = "";

--- a/Package/dist/components/gemini.js
+++ b/Package/dist/components/gemini.js
@@ -93,6 +93,7 @@ class Gemini {
       if (isVideoSummaryActive) {
         // Use video summary functionality
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          if (!tabs.length) return;
           this.summarizeFromGeminiVideoUnderstanding(tabs[0].url);
         });
       } else {
@@ -304,6 +305,7 @@ class Gemini {
       const apiKey = res ? res.apiKey : "";
 
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (!tabs.length) return;
         chrome.tabs.sendMessage(tabs[0].id, { message: "ping" }, (response) => {
           if (chrome.runtime.lastError) {
             summaryListContainer.innerHTML = "";
@@ -449,8 +451,7 @@ class Gemini {
 
   RecordSummaryTab() {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const currentTab = tabs[0];
-      state.summarizedTabId = currentTab.id;
+      state.summarizedTabId = tabs[0]?.id;
     });
   }
 

--- a/Package/dist/popup.js
+++ b/Package/dist/popup.js
@@ -159,6 +159,7 @@ document.addEventListener("visibilitychange", () => {
 document.addEventListener("readystatechange", () => {
   if (document.readyState === "complete") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (!tabs.length) return;
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "finishIframe",
       });
@@ -584,7 +585,9 @@ function measureContentSize(summary = false) {
     state.updateDimensions(currentWidth, currentHeight);
 
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      let contentTabId = summary ? state.summarizedTabId : tabs[0].id;
+      let contentTabId = summary ? state.summarizedTabId : tabs[0]?.id;
+
+      if (contentTabId == null) return;
 
       sendUpdateIframeSize(contentTabId, currentWidth, currentHeight);
 
@@ -623,6 +626,7 @@ function measureContentSizeLast() {
 document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (!tabs.length) return;
       chrome.scripting.executeScript({
         target: { tabId: tabs[0].id },
         files: ["dist/ejectLite.js"],

--- a/tests/gemini.test.js
+++ b/tests/gemini.test.js
@@ -428,6 +428,21 @@ describe("Gemini Component", () => {
       expect(geminiInstance.performNormalContentSummary).toHaveBeenCalled();
       expect(geminiInstance.summarizeFromGeminiVideoUnderstanding).not.toHaveBeenCalled();
     });
+
+    test("should restore button state when no active tab is found (video summary path)", async () => {
+      videoSummaryButton.classList.add("active-button");
+      videoSummaryButton.classList.remove("d-none");
+
+      mockTabsQuery([]);
+
+      sendButton.click();
+
+      await wait(50);
+
+      expect(sendButton.disabled).toBe(false);
+      expect(clearButtonSummary.disabled).toBe(false);
+      expect(geminiInstance.summarizeFromGeminiVideoUnderstanding).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================================================
@@ -1078,6 +1093,24 @@ describe("Gemini Component", () => {
       expect(sendButton.disabled).toBe(false);
       expect(clearButtonSummary.disabled).toBe(false);
       expect(geminiInstance.ResponseErrorMsg).toHaveBeenCalled();
+    });
+
+    test("should restore button state when no active tab is found", async () => {
+      sendButton.disabled = true;
+      clearButtonSummary.disabled = true;
+
+      chrome.runtime.sendMessage.mockImplementation((msg, callback) => {
+        if (callback) callback({ apiKey: "test-api-key" });
+      });
+      mockTabsQuery([]);
+
+      geminiInstance.performNormalContentSummary();
+
+      await wait(50);
+
+      expect(sendButton.disabled).toBe(false);
+      expect(clearButtonSummary.disabled).toBe(false);
+      expect(geminiInstance.getContentAndSummarize).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## 問題

`chrome.tabs.query({ active: true, currentWindow: true })` 在焦點位於 DevTools、獨立面板或沒有可查詢分頁的視窗時會回傳空陣列。以下呼叫點無條件解參考 `tabs[0].id` / `tabs[0].url`,直接 TypeError 中斷流程:

- `background.js`:快捷鍵 handler、`meow()`(圖示點擊注入)
- `popup.js`:`finishIframe` 通知、`measureContentSize`、Esc 關閉
- `gemini.js`:影片摘要、ping 檢查、`RecordSummaryTab`

## 修法

各呼叫點加 `if (!tabs.length) return;` 或改用 optional chaining 後判空提前返回。

## 測試

全部 21 套件 / 1223 個測試通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_