### PR TITLE
refactor: move test-only dependency loading out of shipped popup.js

### DIFF
--- a/Package/dist/popup.js
+++ b/Package/dist/popup.js
@@ -664,16 +664,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-if (typeof State === "undefined" && typeof require !== "undefined") {
-  global.State = require("./hooks/popupState");
-  global.Remove = require("./components/remove");
-  global.Favorite = require("./components/favorite");
-  global.History = require("./components/history");
-  global.Gemini = require("./components/gemini");
-  global.Modal = require("./components/modal");
-  global.Payment = require("./utils/payment");
-}
-
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     initializeDependencies,

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -92,6 +92,16 @@ describe("popup.js", () => {
     teardownPopupDOM();
     jest.resetModules();
     jest.clearAllMocks();
+
+    // Clean up the component constructor globals set in beforeEach to keep
+    // the test environment isolated between tests.
+    delete global.State;
+    delete global.Remove;
+    delete global.Favorite;
+    delete global.History;
+    delete global.Gemini;
+    delete global.Modal;
+    delete global.Payment;
   });
 
   describe("Initialization", () => {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -74,6 +74,16 @@ describe("popup.js", () => {
       return true;
     });
 
+    // Provide the component constructors popup.js resolves as globals in
+    // the browser (top-level class declarations from the other scripts)
+    global.State = State;
+    global.Remove = Remove;
+    global.Favorite = Favorite;
+    global.History = History;
+    global.Gemini = Gemini;
+    global.Modal = Modal;
+    global.Payment = Payment;
+
     // Load popup module AFTER DOM is set up
     popup = require("../Package/dist/popup");
   });


### PR DESCRIPTION
## 問題

`popup.js` 尾端有一段 `if (typeof State === "undefined" && typeof require !== "undefined") { global.State = require(...) ... }` ——純測試用的載入邏輯被打包進出貨的擴充功能。瀏覽器裡這些建構子本來就來自其他 `<script>` 的頂層 class 宣告,這段程式碼在產品中是死碼,還會誤導讀者以為 popup 有模組載入機制。

## 修法

從 `popup.js` 移除該區塊,改由 `popup.test.js` 在 require popup 前自行設定 `global.State` 等建構子(測試檔頂部本來就 require 了這些模組)。

尾端的 `module.exports` guard 保留——它在瀏覽器中無作用且是所有元件共用的慣例;完全移除需要引入建置流程,不符合這次精實修復的範圍。

## 測試

全部 21 套件 / 1223 個測試通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_