### PR TITLE
perf: cache successful API key verification for 24 hours

### DIFF
--- a/Package/dist/background.js
+++ b/Package/dist/background.js
@@ -504,10 +504,49 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 
 const endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest";
 
+// A successful verification is cached (keyed by a hash of the key) so
+// opening the popup doesn't hit the Gemini API every single time.
+const VERIFY_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+async function hashApiKey(apiKey) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(apiKey));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function getVerifyCache() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get("apiKeyVerifyCache", (result) => {
+      resolve(result ? result.apiKeyVerifyCache : undefined);
+    });
+  });
+}
+
 async function verifyApiKey(apiKey) {
+  let keyHash = null;
+  try {
+    keyHash = await hashApiKey(apiKey);
+    const cached = await getVerifyCache();
+    if (
+      cached &&
+      cached.keyHash === keyHash &&
+      cached.valid === true &&
+      Date.now() - cached.verifiedAt < VERIFY_CACHE_TTL
+    ) {
+      return { valid: true };
+    }
+  } catch (_e) {
+    // Hashing/cache problems only mean we verify over the network
+  }
+
   const res = await fetch(endpoint, {
     headers: { "x-goog-api-key": apiKey },
   });
+  // Only cache positive results; failures may be transient
+  if (res.ok && keyHash) {
+    chrome.storage.local.set({
+      apiKeyVerifyCache: { keyHash, valid: true, verifiedAt: Date.now() },
+    });
+  }
   return { valid: res.ok };
 }
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1147,6 +1147,105 @@ describe("background.js", () => {
 
       expect(sendResponse).toHaveBeenCalledWith({ error: "Network failed" });
     });
+
+    describe("verification result caching", () => {
+      const nodeCrypto = require("crypto");
+      const testKeyHash = nodeCrypto.createHash("sha256").update("test-key").digest("hex");
+
+      beforeEach(() => {
+        global.crypto.subtle.digest = jest.fn((algorithm, data) =>
+          Promise.resolve(nodeCrypto.createHash("sha256").update(Buffer.from(data)).digest().buffer)
+        );
+      });
+
+      test("should skip the network when a fresh cached result matches", async () => {
+        const sendResponse = jest.fn();
+        chrome.storage.local.get.mockImplementation((keys, callback) => {
+          callback({
+            apiKeyVerifyCache: {
+              keyHash: testKeyHash,
+              valid: true,
+              verifiedAt: Date.now() - 1000,
+            },
+          });
+        });
+
+        listeners.onMessage[VERIFY_API_LISTENER](
+          { action: "verifyApiKey", apiKey: "test-key" },
+          {},
+          sendResponse
+        );
+        await flushPromises();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(sendResponse).toHaveBeenCalledWith({ valid: true });
+      });
+
+      test("should verify over the network when the cache is stale", async () => {
+        const sendResponse = jest.fn();
+        chrome.storage.local.get.mockImplementation((keys, callback) => {
+          callback({
+            apiKeyVerifyCache: {
+              keyHash: testKeyHash,
+              valid: true,
+              verifiedAt: Date.now() - 25 * 60 * 60 * 1000,
+            },
+          });
+        });
+        mockFetch.mockResolvedValue({ ok: true });
+
+        listeners.onMessage[VERIFY_API_LISTENER](
+          { action: "verifyApiKey", apiKey: "test-key" },
+          {},
+          sendResponse
+        );
+        await flushPromises();
+
+        expect(mockFetch).toHaveBeenCalled();
+        expect(sendResponse).toHaveBeenCalledWith({ valid: true });
+      });
+
+      test("should cache a successful verification", async () => {
+        const sendResponse = jest.fn();
+        chrome.storage.local.get.mockImplementation((keys, callback) => {
+          callback({});
+        });
+        mockFetch.mockResolvedValue({ ok: true });
+
+        listeners.onMessage[VERIFY_API_LISTENER](
+          { action: "verifyApiKey", apiKey: "test-key" },
+          {},
+          sendResponse
+        );
+        await flushPromises();
+
+        expect(chrome.storage.local.set).toHaveBeenCalledWith({
+          apiKeyVerifyCache: expect.objectContaining({
+            keyHash: testKeyHash,
+            valid: true,
+            verifiedAt: expect.any(Number),
+          }),
+        });
+      });
+
+      test("should not cache a failed verification", async () => {
+        const sendResponse = jest.fn();
+        chrome.storage.local.get.mockImplementation((keys, callback) => {
+          callback({});
+        });
+        mockFetch.mockResolvedValue({ ok: false });
+
+        listeners.onMessage[VERIFY_API_LISTENER](
+          { action: "verifyApiKey", apiKey: "test-key" },
+          {},
+          sendResponse
+        );
+        await flushPromises();
+
+        expect(chrome.storage.local.set).not.toHaveBeenCalled();
+        expect(sendResponse).toHaveBeenCalledWith({ valid: false });
+      });
+    });
   });
 
   describe("chrome.runtime.onMessage listener - Payment system", () => {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1153,9 +1153,15 @@ describe("background.js", () => {
       const testKeyHash = nodeCrypto.createHash("sha256").update("test-key").digest("hex");
 
       beforeEach(() => {
-        global.crypto.subtle.digest = jest.fn((algorithm, data) =>
-          Promise.resolve(nodeCrypto.createHash("sha256").update(Buffer.from(data)).digest().buffer)
-        );
+        global.crypto.subtle.digest = jest.fn((algorithm, data) => {
+          const hash = nodeCrypto.createHash("sha256").update(Buffer.from(data)).digest();
+          // Buffer#buffer may reference a larger, pooled ArrayBuffer with a
+          // non-zero byteOffset, so slice out exactly the digest bytes
+          // instead of returning the raw (possibly oversized) buffer.
+          return Promise.resolve(
+            hash.buffer.slice(hash.byteOffset, hash.byteOffset + hash.byteLength)
+          );
+        });
       });
 
       test("should skip the network when a fresh cached result matches", async () => {


### PR DESCRIPTION
## 問題

每次開啟 popup,`fetchAPIKey` 都會向 Gemini API 發一次即時請求重新驗證「沒有變過的 key」——浪費配額、拖慢啟動,也讓每次開 popup 都多一次網路往返。

## 修法

在 background 的 `verifyApiKey`:

- 驗證成功後以 **SHA-256(key) 的雜湊**為鍵,把結果連同時間戳存進 `chrome.storage.local`,TTL 24 小時
- key 換了 → 雜湊不同 → 自動重新驗證;失敗結果**不快取**(可能是暫時性錯誤)
- 雜湊或快取讀取出任何問題就直接 fallback 到網路驗證,行為永不劣於現狀
- 存雜湊而非明文,避免在儲存區留下比現有加密 key 更弱的副本

## 測試

- 全部 21 套件 / 1227 個測試通過
- 新增 4 個測試:快取命中跳過網路、過期快取重新驗證、成功結果寫入快取、失敗結果不寫入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_