### PR TITLE
refactor: replace deprecated sync XHR in i18n with async fetch

### DIFF
--- a/Package/dist/popup.js
+++ b/Package/dist/popup.js
@@ -68,6 +68,7 @@ const paymentSpan = document.querySelector("#paymentButton > span");
 
 // Import Scripts
 let state, remove, favorite, history, gemini, modal, payment, onboarding;
+let lastGeminiApiKey = "";
 
 function initializeDependencies(deps = {}) {
   state = deps.state || new State();
@@ -301,6 +302,7 @@ async function fetchData() {
 
   state.hasInit ? measureContentSizeLast() : retryMeasureContentSize();
 
+  lastGeminiApiKey = geminiApiKey;
   gemini.fetchAPIKey(geminiApiKey);
   modal.updateOptionalModal(startAddr, authUser, historyMax);
   modal.updateIncognitoModal(!!isIncognito);
@@ -513,6 +515,9 @@ window.addEventListener("i18n:changed", () => {
     const v = chrome.i18n.getMessage(key);
     if (v) subtitleElement.textContent = v;
   }
+  // gemini.fetchAPIKey sets apiInput.placeholder / geminiEmptyMessage
+  // imperatively (not via [data-locale]), so it needs its own re-run.
+  if (gemini) gemini.fetchAPIKey(lastGeminiApiKey);
   // Reset buttons to their default width
   [clearButton, cancelButton, clearButtonSummary].forEach((btn) => {
     btn.classList.remove("w-auto");

--- a/Package/dist/utils/i18n.js
+++ b/Package/dist/utils/i18n.js
@@ -13,6 +13,9 @@
 
   let activeLanguage = "auto";
   let overrideMessages = null;
+  // Increments on every applyOverride call so a slow async bundle load can
+  // never clobber a newer language selection.
+  let applyToken = 0;
 
   function readSyncPreference() {
     try {
@@ -44,19 +47,40 @@
     } catch (e) {}
   }
 
-  function loadMessagesSync(lang) {
+  function readValidCache(lang) {
+    const cache = readMessagesCacheSync();
+    return cache && cache.lang === lang && cache.version === EXT_VERSION ? cache.messages : null;
+  }
+
+  // Async fallback for cache misses. Sync XHR is deprecated and blocks the
+  // popup's first paint, so misses render in "auto" first and re-render when
+  // the bundle arrives.
+  async function fetchMessages(lang) {
     // Defense in depth: never let an unexpected lang reach runtime.getURL.
     if (!SUPPORTED_LANGUAGES.includes(lang) || lang === "auto") return null;
     try {
-      const url = chrome.runtime.getURL(`_locales/${lang}/messages.json`);
-      const xhr = new XMLHttpRequest();
-      xhr.open("GET", url, false); // sync XHR is acceptable for a tiny packaged file
-      xhr.send();
-      if (xhr.status === 200) {
-        return JSON.parse(xhr.responseText);
-      }
-    } catch (e) {}
-    return null;
+      const res = await fetch(chrome.runtime.getURL(`_locales/${lang}/messages.json`));
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function applyMessages(lang, messages) {
+    if (messages) {
+      activeLanguage = lang;
+      overrideMessages = messages;
+    } else {
+      activeLanguage = "auto";
+      overrideMessages = null;
+    }
+  }
+
+  function notifyApplied(lang) {
+    if (typeof window === "undefined") return;
+    if (typeof window.applyI18n === "function") window.applyI18n();
+    window.dispatchEvent(new CustomEvent("i18n:changed", { detail: { lang } }));
   }
 
   function applySubstitutions(message, substitutions) {
@@ -79,30 +103,34 @@
     return originalGetMessage(key, substitutions);
   };
 
-  // Cache-first, XHR-fallback. Degrades silently to "auto" on any failure.
-  function applyOverride(lang) {
+  // Cache-first: a valid cache applies synchronously (no flash). On a miss
+  // the bundle loads asynchronously; `notifyOnAsync` re-renders the page when
+  // it lands. Degrades silently to "auto" on any failure. Returns a promise
+  // resolving to the language actually applied.
+  function applyOverride(lang, { notifyOnAsync = false } = {}) {
+    const token = ++applyToken;
+
     if (!lang || lang === "auto" || !SUPPORTED_LANGUAGES.includes(lang)) {
-      activeLanguage = "auto";
-      overrideMessages = null;
-      return;
+      applyMessages("auto", null);
+      return Promise.resolve(activeLanguage);
     }
-    const cache = readMessagesCacheSync();
-    let messages =
-      cache && cache.lang === lang && cache.version === EXT_VERSION ? cache.messages : null;
-    if (!messages) {
-      messages = loadMessagesSync(lang);
+
+    const cached = readValidCache(lang);
+    if (cached) {
+      applyMessages(lang, cached);
+      return Promise.resolve(activeLanguage);
+    }
+
+    return fetchMessages(lang).then((messages) => {
+      if (token !== applyToken) return activeLanguage; // superseded
       if (messages) writeMessagesCache(lang, messages);
-    }
-    if (messages) {
-      activeLanguage = lang;
-      overrideMessages = messages;
-    } else {
-      activeLanguage = "auto";
-      overrideMessages = null;
-    }
+      applyMessages(lang, messages);
+      if (messages && notifyOnAsync) notifyApplied(lang);
+      return activeLanguage;
+    });
   }
 
-  applyOverride(readSyncPreference());
+  applyOverride(readSyncPreference(), { notifyOnAsync: true });
 
   // Mirror storage.local → localStorage so the next popup boot applies the
   // override synchronously (a language set elsewhere takes effect immediately).
@@ -132,7 +160,7 @@
       return activeLanguage;
     },
 
-    setLanguage(lang) {
+    async setLanguage(lang) {
       const normalized = SUPPORTED_LANGUAGES.includes(lang) ? lang : "auto";
       try {
         if (normalized === "auto") {
@@ -142,9 +170,9 @@
           localStorage.setItem(STORAGE_KEY, normalized);
         }
       } catch (e) {}
-      // Apply in-memory immediately (also refreshes cache via loadMessagesSync)
-      // so callers don't need a separate reloadOverride() round-trip.
-      applyOverride(normalized);
+      // Wait for the bundle (also refreshes the cache) so callers can
+      // re-render immediately after this resolves.
+      await applyOverride(normalized);
       return new Promise((resolve) => {
         if (normalized === "auto") {
           chrome.storage.local.remove(STORAGE_KEY, () => resolve(normalized));
@@ -154,10 +182,11 @@
       });
     },
 
-    // Re-applies the stored language in place. Call window.applyI18n() after
-    // this to re-render already-painted data-locale* attributes.
+    // Re-applies the stored language in place. A valid cache applies
+    // synchronously; otherwise the bundle loads in the background and the
+    // page re-renders when it arrives.
     reloadOverride() {
-      applyOverride(readSyncPreference());
+      applyOverride(readSyncPreference(), { notifyOnAsync: true });
       return activeLanguage;
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr40-merge",
+  "name": "google-maps-extension",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -4,7 +4,8 @@
  * The module is an IIFE with side effects at load time:
  *   1. captures chrome.i18n.getMessage as `originalGetMessage`
  *   2. wraps chrome.i18n.getMessage
- *   3. reads localStorage userLanguage and applies the override (sync XHR)
+ *   3. reads localStorage userLanguage and applies the override
+ *      (synchronously from the cache, via async fetch on a miss)
  *   4. registers a chrome.storage.onChanged listener
  *   5. publishes window.I18nUtils
  *
@@ -13,6 +14,7 @@
  */
 
 const path = require("path");
+const { flushPromises } = require("./testHelpers");
 
 const I18N_PATH = path.resolve(__dirname, "../Package/dist/utils/i18n.js");
 
@@ -25,28 +27,22 @@ const EN_MESSAGES = {
 };
 const FALLBACK_MESSAGE_KEY = "searchInputPlaceholder";
 
-/** Install a fake XMLHttpRequest that returns the queued response. */
-function installFakeXhr({ status = 200, body = JA_MESSAGES, throwOnSend = false } = {}) {
-  class FakeXhr {
-    constructor() {
-      this.status = 0;
-      this.responseText = "";
-    }
-    open(_method, url) {
-      this._url = url;
-    }
-    send() {
-      if (throwOnSend) throw new Error("network");
-      this.status = status;
-      this.responseText = JSON.stringify(body);
-      FakeXhr.lastUrl = this._url;
-      FakeXhr.callCount += 1;
-    }
-  }
-  FakeXhr.lastUrl = null;
-  FakeXhr.callCount = 0;
-  global.XMLHttpRequest = FakeXhr;
-  return FakeXhr;
+/** Install a fake fetch that returns the queued response. */
+function installFakeFetch({ status = 200, body = JA_MESSAGES, throwOnSend = false } = {}) {
+  const fakeFetch = jest.fn((url) => {
+    fakeFetch.lastUrl = url;
+    fakeFetch.callCount += 1;
+    if (throwOnSend) return Promise.reject(new Error("network"));
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    });
+  });
+  fakeFetch.lastUrl = null;
+  fakeFetch.callCount = 0;
+  global.fetch = fakeFetch;
+  return fakeFetch;
 }
 
 /** Reset all chrome mocks + storage shims before each load. */
@@ -76,18 +72,18 @@ function seedJaPreferenceAndCache() {
   localStorage.setItem("userLanguage", "ja");
   localStorage.setItem(
     "userLanguageMessages",
-    JSON.stringify({ lang: "ja", messages: JA_MESSAGES })
+    JSON.stringify({ lang: "ja", version: "1.0.0", messages: JA_MESSAGES })
   );
 }
 
 function loadI18nWithJaCache() {
   seedJaPreferenceAndCache();
-  installFakeXhr({ body: JA_MESSAGES });
+  installFakeFetch({ body: JA_MESSAGES });
   return loadI18n();
 }
 
 function getLoadedStorageChangeListener(xhrOptions) {
-  installFakeXhr(xhrOptions);
+  installFakeFetch(xhrOptions);
   loadI18n();
   return chrome.storage.onChanged.addListener.mock.calls[0][0];
 }
@@ -103,106 +99,112 @@ describe("i18n.js", () => {
 
   describe("boot — default", () => {
     test("with no stored preference, activeLanguage is 'auto' and getMessage falls through", () => {
-      installFakeXhr();
+      installFakeFetch();
       const I18nUtils = loadI18n();
 
       expect(I18nUtils.getCurrentLanguage()).toBe("auto");
       expectBrowserFallbackMessage();
       // No XHR should have been issued.
-      expect(global.XMLHttpRequest.callCount).toBe(0);
+      expect(global.fetch.callCount).toBe(0);
     });
   });
 
   describe("boot — override", () => {
-    test("stored 'ja' loads bundle via XHR and overrides getMessage", () => {
+    test("stored 'ja' loads bundle via fetch and overrides getMessage", async () => {
       localStorage.setItem("userLanguage", "ja");
-      const Xhr = installFakeXhr({ body: JA_MESSAGES });
+      const fakeFetch = installFakeFetch({ body: JA_MESSAGES });
 
       const I18nUtils = loadI18n();
+      await flushPromises();
 
       expect(I18nUtils.getCurrentLanguage()).toBe("ja");
-      expect(Xhr.callCount).toBe(1);
-      expect(Xhr.lastUrl).toMatch(/_locales\/ja\/messages\.json$/);
+      expect(fakeFetch.callCount).toBe(1);
+      expect(fakeFetch.lastUrl).toMatch(/_locales\/ja\/messages\.json$/);
       expect(chrome.i18n.getMessage("searchInputPlaceholder")).toBe("Google マップを検索");
     });
 
-    test("unknown key in override bundle falls through to original", () => {
+    test("unknown key in override bundle falls through to original", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ body: JA_MESSAGES });
+      installFakeFetch({ body: JA_MESSAGES });
 
       loadI18n();
+      await flushPromises();
 
       expect(chrome.i18n.getMessage("notInBundle")).toBe("BROWSER:notInBundle");
     });
 
-    test("XHR failure (non-200) degrades silently to auto", () => {
+    test("fetch failure (non-200) degrades silently to auto", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ status: 404 });
+      installFakeFetch({ status: 404 });
 
       const I18nUtils = loadI18n();
+      await flushPromises();
 
       expect(I18nUtils.getCurrentLanguage()).toBe("auto");
       expectBrowserFallbackMessage();
     });
 
-    test("XHR throw degrades silently to auto", () => {
+    test("fetch rejection degrades silently to auto", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ throwOnSend: true });
+      installFakeFetch({ throwOnSend: true });
 
       const I18nUtils = loadI18n();
+      await flushPromises();
 
       expect(I18nUtils.getCurrentLanguage()).toBe("auto");
     });
 
     test("invalid stored language is treated as auto", () => {
       localStorage.setItem("userLanguage", "klingon");
-      installFakeXhr();
+      installFakeFetch();
 
       const I18nUtils = loadI18n();
 
       expect(I18nUtils.getCurrentLanguage()).toBe("auto");
-      expect(global.XMLHttpRequest.callCount).toBe(0);
+      expect(global.fetch.callCount).toBe(0);
     });
   });
 
   describe("messages cache", () => {
-    test("cache is preferred over XHR on next boot", () => {
+    test("cache is preferred over fetch on next boot", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ body: JA_MESSAGES });
+      installFakeFetch({ body: JA_MESSAGES });
       loadI18n();
-      expect(global.XMLHttpRequest.callCount).toBe(1);
+      await flushPromises();
+      expect(global.fetch.callCount).toBe(1);
 
-      installFakeXhr({ body: { searchInputPlaceholder: { message: "FROM_XHR" } } });
+      installFakeFetch({ body: { searchInputPlaceholder: { message: "FROM_FETCH" } } });
       const I18nUtils = loadI18n();
 
-      expect(global.XMLHttpRequest.callCount).toBe(0);
+      expect(global.fetch.callCount).toBe(0);
       expect(I18nUtils.getCurrentLanguage()).toBe("ja");
-      // Message comes from the cache, not the new XHR body.
+      // Message comes from the cache, not a fresh fetch.
       expect(chrome.i18n.getMessage("searchInputPlaceholder")).toBe("Google マップを検索");
     });
 
-    test("cache for a different language is ignored (XHR fires for the new lang)", () => {
+    test("cache for a different language is ignored (fetch fires for the new lang)", async () => {
       localStorage.setItem(
         "userLanguageMessages",
         JSON.stringify({ lang: "en", messages: EN_MESSAGES })
       );
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ body: JA_MESSAGES });
+      installFakeFetch({ body: JA_MESSAGES });
 
       const I18nUtils = loadI18n();
+      await flushPromises();
 
-      expect(global.XMLHttpRequest.callCount).toBe(1);
+      expect(global.fetch.callCount).toBe(1);
       expect(I18nUtils.getCurrentLanguage()).toBe("ja");
     });
   });
 
   describe("setLanguage", () => {
     test("writes both localStorage and chrome.storage.local, pre-caches messages", async () => {
-      installFakeXhr({ body: JA_MESSAGES });
+      installFakeFetch({ body: JA_MESSAGES });
       const I18nUtils = loadI18n();
 
-      // setLanguage triggers another sync XHR to pre-cache.
-      installFakeXhr({ body: JA_MESSAGES });
+      // setLanguage awaits the bundle fetch to pre-cache.
+      installFakeFetch({ body: JA_MESSAGES });
       await I18nUtils.setLanguage("ja");
 
       expect(localStorage.getItem("userLanguage")).toBe("ja");
@@ -229,7 +231,7 @@ describe("i18n.js", () => {
     });
 
     test("invalid lang normalizes to 'auto'", async () => {
-      installFakeXhr();
+      installFakeFetch();
       const I18nUtils = loadI18n();
 
       const result = await I18nUtils.setLanguage("klingon");
@@ -266,12 +268,12 @@ describe("i18n.js", () => {
 
   describe("reloadOverride", () => {
     test("hot-swaps from auto → ja without re-loading the module", () => {
-      installFakeXhr({ body: JA_MESSAGES });
+      installFakeFetch({ body: JA_MESSAGES });
       const I18nUtils = loadI18n();
       expect(I18nUtils.getCurrentLanguage()).toBe("auto");
 
       // Simulate setLanguage having written localStorage (we bypass the
-      // setLanguage XHR by writing directly + seeding cache).
+      // setLanguage fetch by writing directly + seeding a versioned cache).
       seedJaPreferenceAndCache();
 
       const result = I18nUtils.reloadOverride();
@@ -293,22 +295,24 @@ describe("i18n.js", () => {
   });
 
   describe("substitutions", () => {
-    test("$1 / $2 placeholders are interpolated from array substitutions", () => {
+    test("$1 / $2 placeholders are interpolated from array substitutions", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({
+      installFakeFetch({
         body: { greet: { message: "こんにちは $1 さん、$2 へようこそ" } },
       });
       loadI18n();
+      await flushPromises();
 
       expect(chrome.i18n.getMessage("greet", ["太郎", "東京"])).toBe(
         "こんにちは 太郎 さん、東京 へようこそ"
       );
     });
 
-    test("single string substitution is supported", () => {
+    test("single string substitution is supported", async () => {
       localStorage.setItem("userLanguage", "ja");
-      installFakeXhr({ body: { greet: { message: "Hi $1" } } });
+      installFakeFetch({ body: { greet: { message: "Hi $1" } } });
       loadI18n();
+      await flushPromises();
 
       expect(chrome.i18n.getMessage("greet", "太郎")).toBe("Hi 太郎");
     });

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1521,6 +1521,26 @@ describe("popup.js", () => {
       global.requestAnimationFrame = originalGlobalRaf;
       window.requestAnimationFrame = originalWindowRaf;
     });
+
+    test("i18n changed event re-applies gemini's imperatively-set locale strings", () => {
+      const originalGlobalRaf = global.requestAnimationFrame;
+      const originalWindowRaf = window.requestAnimationFrame;
+      global.requestAnimationFrame = jest.fn();
+      window.requestAnimationFrame = jest.fn();
+
+      popup.initializeDependencies({ state: mockState, gemini: mockGemini });
+      mockGemini.fetchAPIKey.mockClear();
+
+      window.dispatchEvent(new Event("i18n:changed"));
+
+      // apiInput.placeholder / geminiEmptyMessage are set via chrome.i18n.getMessage
+      // inside fetchAPIKey, not via [data-locale], so a cache-miss async bundle load
+      // (or a settings-modal language swap) needs this re-run to pick up the new bundle.
+      expect(mockGemini.fetchAPIKey).toHaveBeenCalled();
+
+      global.requestAnimationFrame = originalGlobalRaf;
+      window.requestAnimationFrame = originalWindowRaf;
+    });
   });
 
   describe("Button Tooltips", () => {


### PR DESCRIPTION
## 問題

`i18n.js` 在 localStorage 快取 miss 時用**同步 XHR** 載入語言包——同步 XHR 已被廢棄(console 會出警告),而且會阻塞 popup 首次繪製。

## 修法

- **快取命中(常態)行為不變**:仍在首次繪製前同步套用語言覆寫,零閃爍
- **快取 miss**(跨介面改語言後的第一次開啟、版本升級後)改用 async `fetch`:先以 `auto` 渲染,語言包到達後透過 `window.applyI18n()` + `i18n:changed` 事件重繪
- `setLanguage()` 會等語言包載完才 resolve,設定視窗的切換流程不變
- 加入 apply token,防止慢的載入結果覆蓋較新的語言選擇

## 測試

- 全部 21 套件通過
- i18n 測試的 FakeXhr fixture 改為 fetch fixture,非同步路徑補 `flushPromises`;快取 seed 補上 `version` 欄位(反映模組實際的快取驗證條件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_