### PR TITLE
feat: in-page toast feedback for the auto-attach flow

### DIFF
--- a/Package/_locales/en/messages.json
+++ b/Package/_locales/en/messages.json
@@ -370,5 +370,26 @@
   "tidyLocations" : {
     "message": "Tidy Locations",
     "description": "context menu tidy locations option"
+  },
+  "attachLoadingMsg": {
+    "message": "The Maps Express: finding places on this page…",
+    "description": "auto-attach in-page toast while analyzing"
+  },
+  "attachDoneMsg": {
+    "message": "Attached $count$ map pin(s) 📌",
+    "description": "auto-attach in-page toast on success",
+    "placeholders": {"count": {"content": "$1", "example": "3"}}
+  },
+  "attachNoneMsg": {
+    "message": "No places found on this page",
+    "description": "auto-attach in-page toast when nothing matched"
+  },
+  "attachErrorMsg": {
+    "message": "Couldn't analyze this page. Please try again later.",
+    "description": "auto-attach in-page toast on API error"
+  },
+  "attachMissingMsg": {
+    "message": "Set your Gemini API key in The Maps Express first",
+    "description": "auto-attach in-page toast when API key is missing"
   }
 }

--- a/Package/_locales/ja/messages.json
+++ b/Package/_locales/ja/messages.json
@@ -278,5 +278,26 @@
   },
   "tidyLocations" : {
     "message": "場所を整頓"
+  },
+  "attachLoadingMsg": {
+    "message": "The Maps Express:ページ内のスポットを検索中…",
+    "description": "auto-attach in-page toast while analyzing"
+  },
+  "attachDoneMsg": {
+    "message": "$count$ 件のスポットにピンを付けました 📌",
+    "description": "auto-attach in-page toast on success",
+    "placeholders": {"count": {"content": "$1", "example": "3"}}
+  },
+  "attachNoneMsg": {
+    "message": "このページにスポットは見つかりませんでした",
+    "description": "auto-attach in-page toast when nothing matched"
+  },
+  "attachErrorMsg": {
+    "message": "ページを分析できませんでした。後でもう一度お試しください",
+    "description": "auto-attach in-page toast on API error"
+  },
+  "attachMissingMsg": {
+    "message": "先に The Maps Express で Gemini API キーを設定してください",
+    "description": "auto-attach in-page toast when API key is missing"
   }
 }

--- a/Package/_locales/zh_TW/messages.json
+++ b/Package/_locales/zh_TW/messages.json
@@ -278,5 +278,26 @@
   },
   "tidyLocations" : {
     "message": "整理地點"
+  },
+  "attachLoadingMsg": {
+    "message": "The Maps Express:正在尋找頁面上的地點…",
+    "description": "auto-attach in-page toast while analyzing"
+  },
+  "attachDoneMsg": {
+    "message": "已標記 $count$ 個地點 📌",
+    "description": "auto-attach in-page toast on success",
+    "placeholders": {"count": {"content": "$1", "example": "3"}}
+  },
+  "attachNoneMsg": {
+    "message": "這個頁面上找不到地點",
+    "description": "auto-attach in-page toast when nothing matched"
+  },
+  "attachErrorMsg": {
+    "message": "分析頁面時發生錯誤,請稍後再試",
+    "description": "auto-attach in-page toast on API error"
+  },
+  "attachMissingMsg": {
+    "message": "請先在 The Maps Express 設定 Gemini API 金鑰",
+    "description": "auto-attach in-page toast when API key is missing"
   }
 }

--- a/Package/dist/background.js
+++ b/Package/dist/background.js
@@ -167,6 +167,11 @@ chrome.commands.onCommand.addListener(async (command) => {
           }
         });
       } else if (command === "auto-attach") {
+        // Immediate in-page feedback; replaced by a result/error toast later
+        chrome.tabs.sendMessage(tabId, { action: "attachStatus", stage: "loading" }, () => {
+          // Content script may not be ready yet on this tab; ignore
+          chrome.runtime.lastError;
+        });
         extpay.getUser().then(async (user) => {
           const now = new Date();
 
@@ -218,6 +223,7 @@ async function tryAndCheckApi(tabId) {
   try {
     await getApiKey();
   } catch (error) {
+    chrome.tabs.sendMessage(tabId, { action: "attachStatus", stage: "missing" });
     chrome.tabs.sendMessage(tabId, { action: "consoleQuote", stage: "missing" });
     meow();
     tryAPINotify().catch(() => {});
@@ -237,6 +243,12 @@ async function trySuggest(tabId, retries = 10) {
       if (!response?.content) throw new Error(RECEIVING_END_ERR);
 
       callApi(geminiPrompts.attach, response.content, apiKey, (apiResponse) => {
+        // callApi reports failures as { error }; surface them in-page
+        // instead of handing a non-string to attachMapLinkToPage
+        if (typeof apiResponse !== "string") {
+          chrome.tabs.sendMessage(tabId, { action: "attachStatus", stage: "error" });
+          return;
+        }
         chrome.tabs.sendMessage(tabId, {
           action: "attachMapLink",
           content: apiResponse,

--- a/Package/dist/contentScript.js
+++ b/Package/dist/contentScript.js
@@ -18,7 +18,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.action === "attachMapLink" && request.content) {
-    globalThis.attachMapLinkToPage(request);
+    const attachedCount = globalThis.attachMapLinkToPage(request);
+    if (attachedCount > 0) {
+      showAttachToast(chrome.i18n.getMessage("attachDoneMsg", [String(attachedCount)]));
+    } else {
+      showAttachToast(chrome.i18n.getMessage("attachNoneMsg"));
+    }
+  }
+
+  // Progress/error feedback for the auto-attach flow
+  if (request.action === "attachStatus" && request.stage) {
+    const statusMessages = {
+      loading: chrome.i18n.getMessage("attachLoadingMsg"),
+      missing: chrome.i18n.getMessage("attachMissingMsg"),
+      error: chrome.i18n.getMessage("attachErrorMsg"),
+    };
+    showAttachToast(statusMessages[request.stage], { sticky: request.stage === "loading" });
   }
 
   // Check the connection between the background and the content script
@@ -102,6 +117,41 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
   }
 });
+
+// In-page toast so keyboard-driven flows (auto-attach) give visible feedback
+// instead of only logging to the console. Styles are inline: content-script
+// CSS is not guaranteed to win against host page rules.
+let attachToastTimer = null;
+
+function showAttachToast(text, { sticky = false } = {}) {
+  if (!text || !document.body) return;
+
+  let toast = document.getElementById("TMEattachToast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.id = "TMEattachToast";
+    Object.assign(toast.style, {
+      position: "fixed",
+      right: "16px",
+      bottom: "16px",
+      zIndex: "2147483647",
+      maxWidth: "320px",
+      padding: "10px 14px",
+      borderRadius: "8px",
+      background: "rgba(32, 33, 36, 0.92)",
+      color: "#fff",
+      font: "13px/1.4 system-ui, -apple-system, sans-serif",
+      boxShadow: "0 4px 12px rgba(0, 0, 0, 0.25)",
+      pointerEvents: "none",
+    });
+    document.body.appendChild(toast);
+  }
+
+  toast.textContent = text;
+  clearTimeout(attachToastTimer);
+  // A loading toast stays until replaced by a result, with a safety timeout
+  attachToastTimer = setTimeout(() => toast.remove(), sticky ? 15000 : 2600);
+}
 
 // Get plain text from an element (visible text || including hidden text)
 function getTextContent(element) {

--- a/Package/dist/utils/appSecret.js
+++ b/Package/dist/utils/appSecret.js
@@ -1,9 +1,12 @@
 (() => {
+  // Returns the number of pins attached so the caller can surface feedback
   function attachMapLinkToPage(request) {
     // Handle null, undefined, or empty content
     if (!request || !request.content) {
-      return;
+      return 0;
     }
+
+    let attachedCount = 0;
 
     let candidates = request.content
       .split("\n")
@@ -58,6 +61,7 @@
                 // Create and insert the pin
                 const pin = makePin(searchUrl);
                 textNode.parentNode.insertBefore(pin, textNode.nextSibling);
+                attachedCount++;
 
                 // Add the remaining text if any
                 if (afterText) {
@@ -89,6 +93,8 @@
         attachMapLink(element);
       });
     }
+
+    return attachedCount;
   }
 
   function makePin(href) {

--- a/tests/appSecret.test.js
+++ b/tests/appSecret.test.js
@@ -840,4 +840,26 @@ describe("appSecret.js - Map Link Attachment", () => {
       expect(links.length).toBeGreaterThanOrEqual(0);
     });
   });
+
+  describe("return value (attached pin count)", () => {
+    test("returns the number of pins attached", () => {
+      setBodyHTML("<p>Visit Tokyo Tower today</p><p>Then see Eiffel Tower</p>");
+      const count = attachMapLinkToPage(createRequest("Tokyo Tower\nEiffel Tower"));
+
+      expect(count).toBe(2);
+      expect(getMapLinks().length).toBe(2);
+    });
+
+    test("returns 0 when nothing matches", () => {
+      setBodyHTML("<p>Nothing relevant here</p>");
+      const count = attachMapLinkToPage(createRequest("Louvre Museum"));
+
+      expect(count).toBe(0);
+    });
+
+    test("returns 0 for empty content", () => {
+      expect(attachMapLinkToPage(createRequest(""))).toBe(0);
+      expect(attachMapLinkToPage(null)).toBe(0);
+    });
+  });
 });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1689,6 +1689,58 @@ describe("background.js", () => {
       getApiKey.mockImplementation(originalGetApiKey || (() => Promise.resolve("test-api-key")));
     });
 
+    test("should send a loading status toast when auto-attach starts", async () => {
+      mockExtPayUser({ trialStartedAt: daysAgo(3) });
+      mockAutoAttachContentFlow();
+
+      await runAutoAttachCommand();
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+        1,
+        { action: "attachStatus", stage: "loading" },
+        expect.any(Function)
+      );
+    });
+
+    test("should send a missing-key status toast when no API key is set", async () => {
+      mockExtPayUser({ trialStartedAt: daysAgo(3) });
+
+      const { getApiKey } = require("../Package/dist/hooks/backgroundState.js");
+      const originalGetApiKey = getApiKey.getMockImplementation();
+      getApiKey.mockRejectedValueOnce(new Error("No API key"));
+      chrome.runtime.sendMessage.mockImplementation((message, callback) => {
+        if (callback) callback({});
+      });
+
+      await runAutoAttachCommand();
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, {
+        action: "attachStatus",
+        stage: "missing",
+      });
+
+      getApiKey.mockImplementation(originalGetApiKey || (() => Promise.resolve("test-api-key")));
+    });
+
+    test("should send an error status toast when the Gemini call fails", async () => {
+      mockExtPayUser({ trialStartedAt: daysAgo(3) });
+      mockAutoAttachContentFlow();
+      mockFetch.mockResolvedValue({
+        json: () => Promise.resolve({ error: { message: "quota exceeded" } }),
+      });
+
+      await runAutoAttachCommand();
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, {
+        action: "attachStatus",
+        stage: "error",
+      });
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ action: "attachMapLink" })
+      );
+    });
+
     test("should handle whitespace-only selection", async () => {
       const consoleSpy = jest.spyOn(console, "error").mockImplementation();
 

--- a/tests/contentScript.test.js
+++ b/tests/contentScript.test.js
@@ -363,6 +363,29 @@ describe("contentScript.js - attachMapLink Action", () => {
     expect(globalThis.attachMapLinkToPage).toHaveBeenCalledWith(request);
   });
 
+  test("should show a toast with the attached pin count", () => {
+    globalThis.attachMapLinkToPage = jest.fn(() => 3);
+    chrome.i18n.getMessage.mockImplementation((key, subs) =>
+      key === "attachDoneMsg" ? `Attached ${subs[0]} map pin(s)` : key
+    );
+
+    messageListener({ action: "attachMapLink", content: "data" }, {}, jest.fn());
+
+    const toast = document.getElementById("TMEattachToast");
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe("Attached 3 map pin(s)");
+  });
+
+  test("should show the no-results toast when nothing was attached", () => {
+    globalThis.attachMapLinkToPage = jest.fn(() => 0);
+    chrome.i18n.getMessage.mockImplementation((key) => key);
+
+    messageListener({ action: "attachMapLink", content: "data" }, {}, jest.fn());
+
+    const toast = document.getElementById("TMEattachToast");
+    expect(toast.textContent).toBe("attachNoneMsg");
+  });
+
   test("should not call attachMapLinkToPage when content is missing", () => {
     const request = { action: "attachMapLink" };
     const sendResponse = jest.fn();
@@ -1131,5 +1154,53 @@ describe("contentScript.js - Integration Tests", () => {
 
     expect(sendResponse1).toHaveBeenCalled();
     expect(sendResponse2).toHaveBeenCalledWith({ status: "connected" });
+  });
+});
+
+describe("contentScript.js - attachStatus Action", () => {
+  let messageListener;
+
+  beforeEach(() => {
+    messageListener = setupContentScriptTest();
+    chrome.i18n.getMessage.mockImplementation((key) => key);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("should show the loading toast and keep it up (sticky)", () => {
+    messageListener({ action: "attachStatus", stage: "loading" }, {}, jest.fn());
+
+    const toast = document.getElementById("TMEattachToast");
+    expect(toast.textContent).toBe("attachLoadingMsg");
+
+    // Still visible after the normal toast duration
+    jest.advanceTimersByTime(5000);
+    expect(document.getElementById("TMEattachToast")).not.toBeNull();
+  });
+
+  test("should replace the loading toast with an error toast that auto-dismisses", () => {
+    messageListener({ action: "attachStatus", stage: "loading" }, {}, jest.fn());
+    messageListener({ action: "attachStatus", stage: "error" }, {}, jest.fn());
+
+    const toast = document.getElementById("TMEattachToast");
+    expect(toast.textContent).toBe("attachErrorMsg");
+
+    jest.advanceTimersByTime(3000);
+    expect(document.getElementById("TMEattachToast")).toBeNull();
+  });
+
+  test("should show the missing-key toast", () => {
+    messageListener({ action: "attachStatus", stage: "missing" }, {}, jest.fn());
+
+    expect(document.getElementById("TMEattachToast").textContent).toBe("attachMissingMsg");
+  });
+
+  test("should ignore unknown stages", () => {
+    messageListener({ action: "attachStatus", stage: "bogus" }, {}, jest.fn());
+
+    expect(document.getElementById("TMEattachToast")).toBeNull();
   });
 });


### PR DESCRIPTION
## 問題

Auto-attach(Alt+S)是核心功能,但按下後**頁面上完全沒有回饋**:進度和錯誤只印在 console(哈利波特語錄),使用者要等 pin 出現才知道有在動——沒設 API key 或 Gemini 呼叫失敗時,則是永遠等不到任何反應。

## 實作

**Content script**(`contentScript.js`)
- 新增右下角輕量 toast(inline styles,不依賴頁面 CSS、`pointer-events: none` 不擋操作)
- `attachStatus` 訊息驅動三種狀態:`loading`(sticky,直到被結果取代)/ `missing` / `error`
- attach 完成後依實際釘上的 pin 數顯示「已標記 N 個地點 📌」或「找不到地點」

**`appSecret.js`**
- `attachMapLinkToPage` 回傳實際附加的 pin 數量(原本無回傳值)

**Background**(`background.js`)
- 指令觸發當下立即送 `loading` 狀態(頁面立刻有感)
- 無 API key 時送 `missing`(console 彩蛋保留)
- Gemini 回傳錯誤時送 `error`,不再把 error 物件轉發給 `attachMapLinkToPage`(順帶修掉一個潛在的 TypeError)

**i18n**:en / ja / zh_TW 各新增 5 個訊息鍵(含 `$count$` named placeholder,格式比照 `trialNote`)。

## 測試

- 全部 21 套件 / **1266** 個測試通過(新增 12 個)
- 新測試涵蓋:pin 計數回傳、成功/無結果/loading sticky/error 取代/未知 stage 的 toast 行為、background 三種狀態訊息的發送

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTr9jh2Y9e5pkRAQwuBhx)_