### PR TITLE
feat: show actually assigned shortcuts in the tips modal

### DIFF
--- a/Package/_locales/en/messages.json
+++ b/Package/_locales/en/messages.json
@@ -127,7 +127,7 @@
     "description": "modal tips quick search key label"
   },
   "searchBarKeyLabel": {
-    "message": "Search Bar",
+    "message": "Open Search Bar",
     "description": "modal tips search bar key label"
   },
   "autoAttachKeyLabel": {
@@ -383,5 +383,9 @@
   "tidyLocations" : {
     "message": "Tidy Locations",
     "description": "context menu tidy locations option"
+  },
+  "shortcutUnsetLabel": {
+    "message": "Not Set",
+    "description": "tips modal suffix appended to the default shortcut when no key is assigned"
   }
 }

--- a/Package/_locales/ja/messages.json
+++ b/Package/_locales/ja/messages.json
@@ -97,7 +97,7 @@
     "message": "クイック検索"
   },
   "searchBarKeyLabel": {
-    "message": "検索バー"
+    "message": "検索バーを開く"
   },
   "autoAttachKeyLabel": {
     "message": "リンク自動添付"
@@ -289,5 +289,9 @@
   },
   "tidyLocations" : {
     "message": "場所を整頓"
+  },
+  "shortcutUnsetLabel": {
+    "message": "未設定",
+    "description": "tips modal suffix appended to the default shortcut when no key is assigned"
   }
 }

--- a/Package/_locales/zh_TW/messages.json
+++ b/Package/_locales/zh_TW/messages.json
@@ -97,7 +97,7 @@
     "message": "快速搜尋"
   },
   "searchBarKeyLabel": {
-    "message": "搜尋方塊"
+    "message": "開啟搜尋欄"
   },
   "autoAttachKeyLabel": {
     "message": "自動附加連結"
@@ -289,5 +289,9 @@
   },
   "tidyLocations" : {
     "message": "整理地點"
+  },
+  "shortcutUnsetLabel": {
+    "message": "未設定",
+    "description": "tips modal suffix appended to the default shortcut when no key is assigned"
   }
 }

--- a/Package/dist/components/modal.js
+++ b/Package/dist/components/modal.js
@@ -14,6 +14,7 @@ class Modal {
     await this.loadCrypto();
 
     this._setupShortcutsLinks();
+    this._setupShortcutsDisplay();
     this._setupApiForm();
     this._setupSettingsScrollFade();
     this._setupOptionalModalLifecycle();
@@ -47,6 +48,56 @@ class Modal {
         event.preventDefault();
       };
     }
+  }
+
+  // Suggested keys can be taken by the OS or another extension and silently do nothing;
+  // show what's actually bound instead.
+  _setupShortcutsDisplay() {
+    if (chrome.runtime && typeof chrome.runtime.getPlatformInfo === "function") {
+      chrome.runtime.getPlatformInfo((info) => {
+        this._isMac = info?.os === "mac";
+        this._updateShortcutsDisplay();
+      });
+    } else {
+      this._updateShortcutsDisplay();
+    }
+
+    // The user may (re)assign shortcuts in chrome://extensions/shortcuts without reloading the popup
+    const tipsModal = document.getElementById("tipsModal");
+    if (tipsModal) {
+      tipsModal.addEventListener("show.bs.modal", () => {
+        this._updateShortcutsDisplay();
+      });
+    }
+  }
+
+  // "Alt+R / ⌥+R" -> "Alt+R" on Windows/Linux, "⌥+R" on Mac
+  _defaultShortcutForPlatform(defaultText) {
+    const [primary, mac] = defaultText.split(" / ");
+    return this._isMac && mac ? mac : primary;
+  }
+
+  _updateShortcutsDisplay() {
+    if (!chrome.commands || typeof chrome.commands.getAll !== "function") return;
+
+    chrome.commands.getAll((commands) => {
+      commands.forEach((command) => {
+        const el = document.querySelector(`#tipsModal p[data-command="${command.name}"]`);
+        if (!el) return;
+
+        // Cache the original default text so re-renders don't stack "(Not Set)" onto it
+        if (el.dataset.defaultShortcut === undefined) {
+          el.dataset.defaultShortcut = el.textContent.trim();
+        }
+
+        if (command.shortcut) {
+          el.textContent = command.shortcut;
+        } else {
+          const defaultText = this._defaultShortcutForPlatform(el.dataset.defaultShortcut);
+          el.textContent = `${defaultText} (${chrome.i18n.getMessage("shortcutUnsetLabel")})`;
+        }
+      });
+    });
   }
 
   _setupApiForm() {

--- a/Package/dist/popup.bundle.js
+++ b/Package/dist/popup.bundle.js
@@ -1970,6 +1970,7 @@ class Modal {
     await this.loadCrypto();
 
     this._setupShortcutsLinks();
+    this._setupShortcutsDisplay();
     this._setupApiForm();
     this._setupSettingsScrollFade();
     this._setupOptionalModalLifecycle();
@@ -2003,6 +2004,56 @@ class Modal {
         event.preventDefault();
       };
     }
+  }
+
+  // Suggested keys can be taken by the OS or another extension and silently do nothing;
+  // show what's actually bound instead.
+  _setupShortcutsDisplay() {
+    if (chrome.runtime && typeof chrome.runtime.getPlatformInfo === "function") {
+      chrome.runtime.getPlatformInfo((info) => {
+        this._isMac = info?.os === "mac";
+        this._updateShortcutsDisplay();
+      });
+    } else {
+      this._updateShortcutsDisplay();
+    }
+
+    // The user may (re)assign shortcuts in chrome://extensions/shortcuts without reloading the popup
+    const tipsModal = document.getElementById("tipsModal");
+    if (tipsModal) {
+      tipsModal.addEventListener("show.bs.modal", () => {
+        this._updateShortcutsDisplay();
+      });
+    }
+  }
+
+  // "Alt+R / ⌥+R" -> "Alt+R" on Windows/Linux, "⌥+R" on Mac
+  _defaultShortcutForPlatform(defaultText) {
+    const [primary, mac] = defaultText.split(" / ");
+    return this._isMac && mac ? mac : primary;
+  }
+
+  _updateShortcutsDisplay() {
+    if (!chrome.commands || typeof chrome.commands.getAll !== "function") return;
+
+    chrome.commands.getAll((commands) => {
+      commands.forEach((command) => {
+        const el = document.querySelector(`#tipsModal p[data-command="${command.name}"]`);
+        if (!el) return;
+
+        // Cache the original default text so re-renders don't stack "(Not Set)" onto it
+        if (el.dataset.defaultShortcut === undefined) {
+          el.dataset.defaultShortcut = el.textContent.trim();
+        }
+
+        if (command.shortcut) {
+          el.textContent = command.shortcut;
+        } else {
+          const defaultText = this._defaultShortcutForPlatform(el.dataset.defaultShortcut);
+          el.textContent = `${defaultText} (${chrome.i18n.getMessage("shortcutUnsetLabel")})`;
+        }
+      });
+    });
   }
 
   _setupApiForm() {

--- a/Package/popup.html
+++ b/Package/popup.html
@@ -159,27 +159,27 @@
                     </div>
                     <div class="modal-body">
                         <div class="d-flex justify-content-between mt-3">
-                            <h2 class="fs-6 fw-normal" data-locale="quickSearchKeyLabel"></h2>
-                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel">
-                                Ctrl+Shift+S / &#8984;+&#8679;+S
-                            </p>
-                        </div>
-                        <div class="d-flex justify-content-between">
                             <h2 class="fs-6 fw-normal" data-locale="searchBarKeyLabel"></h2>
-                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel">
+                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel" data-command="_execute_action">
                                 Alt+Shift+S / &#8997;+&#8679;+S
                             </p>
                         </div>
                         <div class="d-flex justify-content-between">
+                            <h2 class="fs-6 fw-normal premium-only" data-locale="autoAttachKeyLabel"></h2>
+                            <p type="button" class="text-muted premium-only" title="Keyboard shortcuts" data-locale-title="shortcutsLabel" data-command="auto-attach">
+                                Alt+S / &#8997;+S
+                            </p>
+                        </div>
+                        <div class="d-flex justify-content-between">
                             <h2 class="fs-6 fw-normal" data-locale="directionsKeyLabel"></h2>
-                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel">
+                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel" data-command="run-directions">
                                 Alt+R / &#8997;+R
                             </p>
                         </div>
                         <div class="d-flex justify-content-between">
-                            <h2 class="fs-6 fw-normal premium-only" data-locale="autoAttachKeyLabel"></h2>
-                            <p type="button" class="text-muted premium-only" title="Keyboard shortcuts" data-locale-title="shortcutsLabel">
-                                Alt+S / &#8997;+S
+                            <h2 class="fs-6 fw-normal" data-locale="quickSearchKeyLabel"></h2>
+                            <p type="button" class="text-muted" title="Keyboard shortcuts" data-locale-title="shortcutsLabel" data-command="run-search">
+                                Ctrl+Shift+S / &#8984;+&#8679;+S
                             </p>
                         </div>
                     </div>

--- a/tests/modal.test.js
+++ b/tests/modal.test.js
@@ -38,6 +38,12 @@ const setupGlobalDOMElements = () => {
         <p class="modal-body-configure"></p>
         <p class="modal-body-configure"></p>
         <p class="modal-body-configure"></p>
+        <div id="tipsModal">
+            <p class="text-muted" data-command="_execute_action">Alt+Shift+S</p>
+            <p class="text-muted premium-only" data-command="auto-attach">Alt+S</p>
+            <p class="text-muted" data-command="run-directions">Alt+R</p>
+            <p class="text-muted" data-command="run-search">Ctrl+Shift+S</p>
+        </div>
         <p id="geminiEmptyMessage" class="d-none"></p>
         <button id="sendButton"></button>
         <div id="incognitoToggle" class="settings-toggle-item">
@@ -242,6 +248,112 @@ describe("Modal Component - Full Coverage", () => {
     // is captured in closure when addModalListener() runs, making it hard to mock.
     // Lines 28-29 (Opera URL) remain uncovered. This is acceptable as it's just
     // browser detection logic that's better tested in E2E tests.
+  });
+
+  // addModalListener - Shortcuts Display (actual assignments)
+
+  describe("addModalListener - Shortcuts Display", () => {
+    const getRow = (command) => document.querySelector(`#tipsModal p[data-command="${command}"]`);
+
+    test("should show the actually assigned shortcut for each command", async () => {
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([
+          { name: "run-search", shortcut: "Ctrl+Shift+S" },
+          { name: "auto-attach", shortcut: "Alt+S" },
+        ])
+      );
+
+      await modalInstance.addModalListener();
+
+      expect(getRow("run-search").textContent).toBe("Ctrl+Shift+S");
+      expect(getRow("auto-attach").textContent).toBe("Alt+S");
+    });
+
+    test("should append the Not Set suffix to the default text when no key is assigned", async () => {
+      chrome.i18n.getMessage.mockImplementation((key) =>
+        key === "shortcutUnsetLabel" ? "Not Set" : key
+      );
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "auto-attach", shortcut: "" }])
+      );
+
+      await modalInstance.addModalListener();
+
+      // "Alt+S" is the row's original (default) text from popup.html
+      expect(getRow("auto-attach").textContent).toBe("Alt+S (Not Set)");
+    });
+
+    test("should not stack the Not Set suffix across repeated opens while still unassigned", async () => {
+      chrome.i18n.getMessage.mockImplementation((key) =>
+        key === "shortcutUnsetLabel" ? "Not Set" : key
+      );
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "auto-attach", shortcut: "" }])
+      );
+
+      await modalInstance.addModalListener();
+      document.getElementById("tipsModal").dispatchEvent(new Event("show.bs.modal"));
+      document.getElementById("tipsModal").dispatchEvent(new Event("show.bs.modal"));
+
+      expect(getRow("auto-attach").textContent).toBe("Alt+S (Not Set)");
+    });
+
+    test("should show the plain assigned shortcut once a key is assigned again", async () => {
+      chrome.i18n.getMessage.mockImplementation((key) =>
+        key === "shortcutUnsetLabel" ? "Not Set" : key
+      );
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "auto-attach", shortcut: "" }])
+      );
+      await modalInstance.addModalListener();
+      expect(getRow("auto-attach").textContent).toBe("Alt+S (Not Set)");
+
+      // User assigns a key, then reopens the tips modal
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "auto-attach", shortcut: "Alt+S" }])
+      );
+      document.getElementById("tipsModal").dispatchEvent(new Event("show.bs.modal"));
+
+      expect(getRow("auto-attach").textContent).toBe("Alt+S");
+    });
+
+    test("should show the Mac half of the default text when the platform is mac", async () => {
+      chrome.runtime.getPlatformInfo.mockImplementation((callback) => callback({ os: "mac" }));
+      chrome.i18n.getMessage.mockImplementation((key) =>
+        key === "shortcutUnsetLabel" ? "Not Set" : key
+      );
+      getRow("run-directions").textContent = "Alt+R / ⌥+R";
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "run-directions", shortcut: "" }])
+      );
+
+      await modalInstance.addModalListener();
+
+      expect(getRow("run-directions").textContent).toBe("⌥+R (Not Set)");
+    });
+
+    test("should show the Windows/Linux half of the default text on other platforms", async () => {
+      chrome.runtime.getPlatformInfo.mockImplementation((callback) => callback({ os: "win" }));
+      chrome.i18n.getMessage.mockImplementation((key) =>
+        key === "shortcutUnsetLabel" ? "Not Set" : key
+      );
+      getRow("run-directions").textContent = "Alt+R / ⌥+R";
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "run-directions", shortcut: "" }])
+      );
+
+      await modalInstance.addModalListener();
+
+      expect(getRow("run-directions").textContent).toBe("Alt+R (Not Set)");
+    });
+
+    test("should ignore commands without a matching row", async () => {
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "unknown-command", shortcut: "Alt+X" }])
+      );
+
+      await expect(modalInstance.addModalListener()).resolves.not.toThrow();
+    });
   });
 
   // addModalListener - API Form Submission

--- a/tests/modal.test.js
+++ b/tests/modal.test.js
@@ -269,6 +269,21 @@ describe("Modal Component - Full Coverage", () => {
       expect(getRow("auto-attach").textContent).toBe("Alt+S");
     });
 
+    test("should still show shortcuts when chrome.runtime.getPlatformInfo is unavailable", async () => {
+      const originalGetPlatformInfo = chrome.runtime.getPlatformInfo;
+      delete chrome.runtime.getPlatformInfo;
+
+      chrome.commands.getAll.mockImplementation((callback) =>
+        callback([{ name: "run-search", shortcut: "Ctrl+Shift+S" }])
+      );
+
+      await modalInstance.addModalListener();
+
+      expect(getRow("run-search").textContent).toBe("Ctrl+Shift+S");
+
+      chrome.runtime.getPlatformInfo = originalGetPlatformInfo;
+    });
+
     test("should append the Not Set suffix to the default text when no key is assigned", async () => {
       chrome.i18n.getMessage.mockImplementation((key) =>
         key === "shortcutUnsetLabel" ? "Not Set" : key

--- a/tests/popupDOMFixture.js
+++ b/tests/popupDOMFixture.js
@@ -141,9 +141,10 @@ function createPopupDOM() {
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <p class="premium-only" data-locale="shortcutsNote">Configure shortcuts</p>
-            <p class="premium-only" data-locale="shortcutsNote">Configure shortcuts</p>
-            <p class="premium-only" data-locale="shortcutsNote">Configure shortcuts</p>
+            <p class="text-muted" data-command="_execute_action">Alt+Shift+S</p>
+            <p class="text-muted premium-only" data-command="auto-attach">Alt+S</p>
+            <p class="text-muted" data-command="run-directions">Alt+R</p>
+            <p class="text-muted" data-command="run-search">Ctrl+Shift+S</p>
           </div>
         </div>
       </div>

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -41,6 +41,7 @@ global.chrome = {
     lastError: null,
     getURL: jest.fn((path) => `chrome-extension://mock-id/${path}`),
     getManifest: jest.fn(() => ({ version: "1.0.0" })),
+    getPlatformInfo: jest.fn((callback) => callback && callback({ os: "win" })),
   },
   storage: {
     local: {
@@ -84,6 +85,7 @@ global.chrome = {
     onCommand: {
       addListener: jest.fn(),
     },
+    getAll: jest.fn((callback) => callback && callback([])),
   },
   action: {
     onClicked: {
@@ -157,7 +159,7 @@ global.chrome = {
         tidyLocations: "Tidy Locations",
         getDirections: "Get Directions",
         quickSearchKeyLabel: "Quick Search",
-        searchBarKeyLabel: "Search Bar",
+        searchBarKeyLabel: "Open Search Bar",
         autoAttachKeyLabel: "Auto Attach",
         directionsKeyLabel: "Directions",
         shortcutsNote: "Configure shortcuts in browser settings",


### PR DESCRIPTION
## 問題

Tips modal 顯示的是寫死的建議快捷鍵（`Alt+S`、`Ctrl+Shift+S`…）。但 manifest 的 `suggested_key` 被作業系統或其他擴充功能占用時會靜默失效——使用者照著畫面按，什麼都不會發生。

## 實作

- `popup.html` 四列快捷鍵加上 `data-command`（對應 manifest 的 command 名稱），並調整顯示順序與 `chrome://extensions/shortcuts` 頁面（依 command id 字母排序）一致
- `modal.js` 新增 `_setupShortcutsDisplay()` / `_updateShortcutsDisplay()`：用 `chrome.commands.getAll()` 查本機實際指派的按鍵
- 未指派時，用 `chrome.runtime.getPlatformInfo()` 判斷平台，顯示對應的預設建議鍵（Mac 用 `⌥` 符號、其他平台用 `Alt`）並標註 `(Not Set)`
- 每次打開 tips modal 都重新查詢，改完指派回來不用重開 popup
- i18n 新增 `shortcutUnsetLabel` ×3 語系；`searchBarKeyLabel` 順手改成「開啟搜尋欄 / Open Search Bar / 検索バーを開く」

## 與 #45 的差異

此 PR 取代 #45。#45 是在 main 的 popup DOM/state 重構（`425dc8e` 等）之前開的，直接合併會與目前的 `history.js`／`gemini.js`／測試檔產生真正的內容衝突。這個分支是從目前 main 重新分出、重新實作同樣的功能，並依 code review 與後續討論做了幾點調整：
- `.shortcut-unset` 沒有走顏色/底線特殊樣式，改成純文字顯示（跟一般列一樣）
- 未指派時保留原本平台對應的預設建議鍵文字，而非完全替換成「未設定」
- tips modal 顯示順序對齊 Edge 快捷鍵設定頁的字母排序

## 測試

全套 21 套件 / 1293 個測試通過（新增 7 個涵蓋 shortcuts display，含 Mac/Windows 平台判定）。`npm run lint`、`npm run format:check` 皆乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)