### PR TITLE
fix(i18n): 修正付款按鈕金額顯示消失的問題

### DIFF
--- a/Package/_locales/en/messages.json
+++ b/Package/_locales/en/messages.json
@@ -231,7 +231,7 @@
     "description": "modal more feature label"
   },
   "paymentLabel": {
-    "message": "Life Time $9.00",
+    "message": "Life Time $$9.00",
     "description": "modal pricing label"
   },
   "restoreLabel": {

--- a/Package/_locales/ja/messages.json
+++ b/Package/_locales/ja/messages.json
@@ -175,7 +175,7 @@
     "message": "\ud83d\udd25今後、さらに多くの上級魔法"
   },
   "paymentLabel": {
-    "message": "永久使用 $9.00"
+    "message": "永久使用 $$9.00"
   },
   "restoreLabel": {
     "message": "購入を復元"

--- a/Package/_locales/zh_TW/messages.json
+++ b/Package/_locales/zh_TW/messages.json
@@ -175,7 +175,7 @@
     "message": "\ud83d\udd25將會有更多的高級魔法"
   },
   "paymentLabel": {
-    "message": "永久使用 $9.00"
+    "message": "永久使用 $$9.00"
   },
   "restoreLabel": {
     "message": "恢復購買"

--- a/Package/dist/utils/i18n.js
+++ b/Package/dist/utils/i18n.js
@@ -79,14 +79,20 @@
     });
   }
 
+  // Protect literal "$$" (Chrome's escape for a literal "$") from the
+  // placeholder/substitution regexes below, then restore it at the end.
+  const DOLLAR_SENTINEL = "@@DOLLAR@@";
+
   function applySubstitutions(message, substitutions, placeholders) {
-    let result = resolveNamedPlaceholders(message, placeholders);
-    if (substitutions == null) return result;
-    const subs = Array.isArray(substitutions) ? substitutions : [substitutions];
-    subs.forEach((value, index) => {
-      result = result.replace(new RegExp("\\$" + (index + 1), "g"), String(value));
-    });
-    return result;
+    let result = message.replace(/\$\$/g, DOLLAR_SENTINEL);
+    result = resolveNamedPlaceholders(result, placeholders);
+    if (substitutions != null) {
+      const subs = Array.isArray(substitutions) ? substitutions : [substitutions];
+      subs.forEach((value, index) => {
+        result = result.replace(new RegExp("\\$" + (index + 1), "g"), String(value));
+      });
+    }
+    return result.split(DOLLAR_SENTINEL).join("$");
   }
 
   chrome.i18n.getMessage = function (key, substitutions) {

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -341,5 +341,16 @@ describe("i18n.js", () => {
 
       expect(chrome.i18n.getMessage("deleteBtnText", "3")).toBe("3 件の場所を削除");
     });
+
+    test("$$ escapes to a literal $ instead of being consumed as a placeholder", async () => {
+      localStorage.setItem("userLanguage", "ja");
+      installFakeFetch({
+        body: { paymentLabel: { message: "永久使用 $$9.00" } },
+      });
+      loadI18n();
+      await flushPromises();
+
+      expect(chrome.i18n.getMessage("paymentLabel")).toBe("永久使用 $9.00");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- 付款彈窗按鈕文字「Life Time \$9.00」實際顯示成「Life Time .00」——Chrome i18n 把裸露的 `\$9` 當成未提供的替代參數索引而清空，依規範跳脫成 `\$\$9.00`
- 同步修正自製語言覆寫層（`Package/dist/utils/i18n.js`）的替代邏輯，補上 `\$\$` → `\$` 反跳脫，避免使用者手動切換語言時改顯示雙錢字號

## Test plan
- [x] `tests/i18n.test.js` 新增回歸測試，覆蓋 override 路徑下 `\$\$` 正確反跳脫（fail-then-pass 驗證過）
- [x] `npm test` 全數通過（1295/1295）
- [x] `npm run lint` 無警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)